### PR TITLE
fix: simplify-review fixes (convergent + skills findings)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,103 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+CredMesh-Solana is a pre-implementation port of [CredMesh](https://github.com/unbrained-labs/credmesh) (programmable credit protocol for autonomous agents) from EVM (Base) to Solana. The EVM protocol is live at https://credmesh.xyz; this repo is the Anchor scaffold + design + research that gets it to Solana.
+
+Status: handler bodies written end-to-end but **not compile-verified**. First `anchor build` will surface 1-3 minor Anchor 0.30 syntax fixes.
+
+## Read order (before touching code)
+
+1. **`DECISIONS.md`** — five blocking design questions answered with rationale (MPL Agent Registry vs SATI, Squads onboarding flow, Sybil mitigation, SAS roadmap, fee-payer infra).
+2. **`AUDIT.md`** — three independent reviews + final-review pass; all P0/P1 fixes applied with cross-references in code as `// AUDIT P0-X` comments.
+3. **`DESIGN.md`** — implementer spec (programs, PDAs, instructions, invariants, threat model).
+4. **`research/HANDLER_PATTERNS.md`** — canonical Solana lending patterns (MarginFi/Solend/Kamino/Drift/Squads) lifted byte-for-byte at pinned commit hashes. **The handler-implementation reference manual.**
+5. **`V1_ACCEPTANCE.md`** — what "v1 ready to ship" means.
+6. **`DEPLOYMENT.md`** — devnet/mainnet deploy procedure + key rotation.
+7. **`research/CONTRARIAN.md`** — why we redesigned where we did (vs literal EVM port).
+8. **`research/REVIEW.md`**, `research/SYNTHESIS.md`, `research/01-04` — supporting research.
+
+## Commands
+
+```bash
+# Toolchain (see CONTRIBUTING.md for full setup)
+rustup default 1.79.0
+sh -c "$(curl -sSfL https://release.anza.xyz/v1.18.26/install)"
+cargo install --git https://github.com/coral-xyz/anchor avm --force && avm install 0.30.1
+
+anchor build                                 # build all 4 programs
+anchor test --skip-local-validator           # bankrun tests
+npm install && npm test                      # ts-mocha + bankrun
+
+# TS server
+cd ts/server && npm install && npm run dev   # http://localhost:3000
+```
+
+## Architecture
+
+### Workspace layout
+
+```
+programs/
+├── credmesh-shared/                 seeds, program IDs, helpers (mpl_identity,
+│                                    cross_program, ix_introspection)
+├── credmesh-escrow/                 Pool vault + share-mint + advance + waterfall
+├── credmesh-reputation/             8004-shape rolling-digest reputation
+└── credmesh-receivable-oracle/      worker + ed25519 payer-signed receivables
+ts/server/                           Hono backend (SIWS auth, tx-builder, webhook ingress)
+tests/bankrun/                       anchor-bankrun unit/integration + AUDIT-finding fixtures
+```
+
+### External programs CredMesh **uses** but does not deploy
+
+- **Squads v4** (`SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf`) — agent vaults, SpendingLimits, governance multisig
+- **MPL Agent Registry** (`1DREGFgysWYxLnRnKQnwrxnJQeSMk2HmGaC6whw2B2p`) + **MPL Agent Tools** (`TLREGni9ZEyGC3vnPZtqUh95xQ8oPqJSvNjvB7FGK8S`) — agent identity + DelegateExecutionV1
+- **MPL Core** (`CoREENxT6tW1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7d`) — base asset primitive
+- **SPL Token classic** — USDC vault and share mint
+- **ed25519 program** + **Memo v2** — receivable verification + replay-nonce binding
+
+## Conventions specific to this repo
+
+- **Cross-program reads use the four-step verify** (owner → address → discriminator → typed deserialize) via `credmesh_shared::cross_program::read_cross_program_account<T>`. Forgetting any step is the Wormhole-class bug. **Don't skip steps.**
+- **PDA seeds come from `credmesh-shared::seeds`.** Never re-declare seed bytes in two crates — they will silently drift.
+- **`ConsumedPayment` is permanent** (AUDIT P0-5). Closing it reopens close-then-reinit replay. Don't add a close handler.
+- **`request_advance` has no pause path.** Advance issuance is never gated by governance. The "no pause on issuance" invariant is load-bearing — see DESIGN §3.5 and AUDIT P0-6.
+- **`claim_and_settle` requires `cranker == advance.agent` in v1.** Permissionless cranking is deferred — needs a payer-pre-auth pattern that doesn't exist yet (AUDIT P0-3/P0-4).
+- **Three-key topology** (DESIGN §10): fee-payer, oracle worker authority, reputation writer authority must NEVER share keys. The off-chain config and rotation flow enforce this.
+- **All math is `checked_*`** or wrapped in u128. Cargo.toml sets `overflow-checks = true` in release; don't rely on it.
+- **Errors map to typed enums** (`CredmeshError`, `ReputationError`, `OracleError`). No `unwrap()` in handlers.
+- **Cross-program seed constants come from `credmesh-shared`.** Each program `pub use`s only the seeds it actually uses, so its own clients can derive PDAs without depending on `credmesh-shared`.
+- **Events are emitted as the LAST step of each handler.** A partial failure mid-handler shouldn't emit a misleading event.
+- **No `find_program_address` in hot paths** when the bump is already cached. Per HANDLER_PATTERNS.md Pattern 2 (~1500 CU per call). Use `Pubkey::create_program_address(seeds_with_bump, program_id)` instead.
+- **`emit!` is the LAST line.** Anti-pattern: emitting before all CPIs succeed.
+
+## What NOT to do
+
+- Don't add a `paused` field back to `Pool`. The "no pause on issuance" invariant is load-bearing — AUDIT P0-6.
+- Don't close `ConsumedPayment`. Permanent. AUDIT P0-5.
+- Don't make `claim_and_settle` permissionless in v1. AUDIT P0-3/P0-4.
+- Don't introduce Light Protocol compressed PDAs or Token-2022 features in v1. Both are explicitly v2+.
+- Don't add per-record SQL persistence on the off-chain server. State migrates to on-chain PDAs (DESIGN §6); SQLite is a derived-view cache only.
+- Don't use `init_if_needed` for replay-protection PDAs — only `init`. AUDIT P0-5.
+- Don't use bare `transfer` — Token-2022 forward-compat requires `transfer_checked`.
+
+## V1 explicitly NOT in scope (deferred)
+
+Per DESIGN §9:
+- ML-derived credit curves
+- Mobile Wallet Adapter / Solana Mobile
+- Hyperliquid Lazer publisher
+- Light Protocol compressed PDAs
+- Plain-EOA agents (Squads-only for v1)
+- Multi-asset pools (USDC only)
+- Per-instruction-type timelock granularity
+- Token-2022 USDC handling
+- Embedded-wallet (Phantom Portal) auth
+- Permissionless `claim_and_settle` cranking
+- Multi-issuer SAS attestations (deferred to v1.5; schema documented now)
+
+## Sister repo
+
+The original EVM CredMesh lives at `../credmesh/`. When porting logic (e.g., `pricing.ts` → `compute_fee_amount` in escrow), the EVM file is the source of truth for math; the Solana file mirrors it. Tests assert the on-chain quote and the off-chain quote match exactly.

--- a/programs/credmesh-escrow/src/errors.rs
+++ b/programs/credmesh-escrow/src/errors.rs
@@ -56,4 +56,6 @@ pub enum CredmeshError {
     WaterfallSumMismatch,
     #[msg("Late days exceed maximum cap")]
     LateDaysExceeded,
+    #[msg("Payment amount is less than total owed (principal + fee + late penalty)")]
+    InsufficientPayment,
 }

--- a/programs/credmesh-escrow/src/lib.rs
+++ b/programs/credmesh-escrow/src/lib.rs
@@ -274,39 +274,19 @@ pub mod credmesh_escrow {
                         _ => error!(CredmeshError::Ed25519Missing),
                     })?;
 
+                let decoded = credmesh_shared::ed25519_message::decode(&signed_msg)
+                    .ok_or(CredmeshError::Ed25519MessageMismatch)?;
                 require!(
-                    signed_msg.len() == credmesh_shared::ed25519_message::TOTAL_LEN,
-                    CredmeshError::Ed25519MessageMismatch
-                );
-
-                use credmesh_shared::ed25519_message as M;
-                let msg_recv_id = &signed_msg[M::RECEIVABLE_ID_OFFSET
-                    ..M::RECEIVABLE_ID_OFFSET + M::RECEIVABLE_ID_LEN];
-                let msg_agent =
-                    &signed_msg[M::AGENT_OFFSET..M::AGENT_OFFSET + M::AGENT_LEN];
-                let mut amount_buf = [0u8; 8];
-                amount_buf.copy_from_slice(
-                    &signed_msg[M::AMOUNT_OFFSET..M::AMOUNT_OFFSET + M::AMOUNT_LEN],
-                );
-                let msg_amount = u64::from_le_bytes(amount_buf);
-                let mut expires_buf = [0u8; 8];
-                expires_buf.copy_from_slice(
-                    &signed_msg[M::EXPIRES_AT_OFFSET..M::EXPIRES_AT_OFFSET + M::EXPIRES_AT_LEN],
-                );
-                let msg_expires_at = i64::from_le_bytes(expires_buf);
-                let msg_nonce = &signed_msg[M::NONCE_OFFSET..M::NONCE_OFFSET + M::NONCE_LEN];
-
-                require!(
-                    msg_recv_id == receivable_id.as_ref(),
+                    decoded.receivable_id == receivable_id,
                     CredmeshError::Ed25519MessageMismatch
                 );
                 require!(
-                    msg_agent == ctx.accounts.agent_asset.key().as_ref(),
+                    decoded.agent == ctx.accounts.agent_asset.key().to_bytes(),
                     CredmeshError::Ed25519MessageMismatch
                 );
-                require!(msg_nonce == nonce.as_ref(), CredmeshError::Ed25519MessageMismatch);
+                require!(decoded.nonce == nonce, CredmeshError::Ed25519MessageMismatch);
 
-                (msg_amount, msg_expires_at, Some(signed_pubkey))
+                (decoded.amount, decoded.expires_at, Some(signed_pubkey))
             }
         };
 
@@ -433,7 +413,7 @@ pub mod credmesh_escrow {
         let expires_at = ctx.accounts.advance.expires_at;
 
         let late_seconds = (now - expires_at).max(0);
-        let mut late_days = (late_seconds / 86_400) as u64;
+        let mut late_days = (late_seconds / SECONDS_PER_DAY as i64) as u64;
         if late_days > MAX_LATE_DAYS as u64 {
             late_days = MAX_LATE_DAYS as u64;
         }
@@ -446,7 +426,7 @@ pub mod credmesh_escrow {
             .ok_or(CredmeshError::MathOverflow)?
             .checked_add(late_penalty)
             .ok_or(CredmeshError::MathOverflow)?;
-        require!(payment_amount >= total_owed, CredmeshError::WaterfallSumMismatch);
+        require!(payment_amount >= total_owed, CredmeshError::InsufficientPayment);
 
         // Compute three cuts. Fee + late penalty splits 15/85; principal
         // returns to LP vault in full.
@@ -724,8 +704,8 @@ fn preview_deposit(amount: u64, total_assets: u64, total_shares: u64) -> Result<
 ///         score 80 → $100; score 95+ → $250 (KYC tier).
 /// Hard ceiling = pool.max_advance_abs.
 fn credit_from_score_ema(score_ema: u128, _curve: &FeeCurve) -> Result<u64> {
-    // score_ema is u128 with 18 decimals — divide by 10^18 to get integer 0..100.
-    let score_int = (score_ema / 1_000_000_000_000_000_000u128) as u64;
+    // score_ema is u128 with 18 decimals — divide by SCORE_SCALE to get integer 0..100.
+    let score_int = (score_ema / SCORE_SCALE) as u64;
     let credit_usd = match score_int {
         0..=20 => 0u64,
         21..=49 => 10_000_000,   // $10
@@ -770,7 +750,7 @@ fn compute_fee_amount(
     }
 
     // Duration premium.
-    let duration_days = duration_seconds / 86_400;
+    let duration_days = duration_seconds / SECONDS_PER_DAY;
     rate_bps = rate_bps
         .checked_add(duration_days.saturating_mul(curve.duration_per_day_bps as u64))
         .ok_or(CredmeshError::MathOverflow)?;
@@ -792,9 +772,10 @@ fn compute_fee_amount(
 }
 
 fn compute_late_penalty_per_day(principal: u64, curve: &FeeCurve) -> Result<u64> {
-    // 0.1% per day of principal, multiplied by pool_loss_surcharge_bps if active.
+    // LATE_PENALTY_BPS_PER_DAY (= 10 bps = 0.1%) of principal, multiplied by
+    // pool_loss_surcharge_bps if active.
     let base = (principal as u128)
-        .checked_mul(10) // 0.1% = 10 bps
+        .checked_mul(LATE_PENALTY_BPS_PER_DAY as u128)
         .ok_or(CredmeshError::MathOverflow)?
         .checked_div(BPS_DENOMINATOR as u128)
         .ok_or(CredmeshError::MathOverflow)?;

--- a/programs/credmesh-escrow/src/state.rs
+++ b/programs/credmesh-escrow/src/state.rs
@@ -1,9 +1,11 @@
 use anchor_lang::prelude::*;
 
-pub use credmesh_shared::seeds::{ADVANCE_SEED, CONSUMED_SEED, POOL_SEED, TREASURY_SEED};
+pub use credmesh_shared::seeds::{ADVANCE_SEED, CONSUMED_SEED, POOL_SEED};
+pub use credmesh_shared::{SCORE_SCALE, SECONDS_PER_DAY};
 
 pub const PROTOCOL_FEE_BPS: u16 = 1500;
 pub const BPS_DENOMINATOR: u64 = 10_000;
+pub const LATE_PENALTY_BPS_PER_DAY: u64 = 10;
 
 pub const CLAIM_WINDOW_SECONDS: i64 = 7 * 24 * 60 * 60;
 pub const LIQUIDATION_GRACE_SECONDS: i64 = 14 * 24 * 60 * 60;
@@ -131,6 +133,4 @@ impl ConsumedPayment {
 }
 
 // ProtocolTreasury is not a separate PDA in v1 — `Pool.treasury_ata` stores the
-// destination ATA directly. The TREASURY_SEED constant is reserved for v2 if a
-// dedicated PDA is ever needed (e.g., to track per-pool fee accrual on-chain
-// independently of the ATA balance).
+// destination ATA directly.

--- a/programs/credmesh-receivable-oracle/src/lib.rs
+++ b/programs/credmesh-receivable-oracle/src/lib.rs
@@ -23,6 +23,7 @@ pub mod credmesh_receivable_oracle {
         let config = &mut ctx.accounts.config;
         config.bump = ctx.bumps.config;
         config.governance = params.governance;
+        config.pending_governance = None;
         config.worker_authority = params.worker_authority;
         config.worker_max_per_tx = params.worker_max_per_tx;
         config.worker_max_per_period = params.worker_max_per_period;
@@ -137,43 +138,15 @@ pub mod credmesh_receivable_oracle {
             OracleError::SignerNotAllowed
         );
 
-        // (3) Decode the message bytes per the canonical 96-byte layout.
+        let decoded = credmesh_shared::ed25519_message::decode(&signed_message)
+            .ok_or(OracleError::Ed25519Missing)?;
+        require!(decoded.receivable_id == source_id, OracleError::Ed25519Missing);
         require!(
-            signed_message.len() == credmesh_shared::ed25519_message::TOTAL_LEN,
+            decoded.agent == ctx.accounts.agent.key().to_bytes(),
             OracleError::Ed25519Missing
         );
-        use credmesh_shared::ed25519_message as M;
-        let msg_recv_id =
-            &signed_message[M::RECEIVABLE_ID_OFFSET..M::RECEIVABLE_ID_OFFSET + M::RECEIVABLE_ID_LEN];
-        let msg_agent =
-            &signed_message[M::AGENT_OFFSET..M::AGENT_OFFSET + M::AGENT_LEN];
-        let mut amount_buf = [0u8; 8];
-        amount_buf.copy_from_slice(
-            &signed_message[M::AMOUNT_OFFSET..M::AMOUNT_OFFSET + M::AMOUNT_LEN],
-        );
-        let msg_amount = u64::from_le_bytes(amount_buf);
-        let mut expires_buf = [0u8; 8];
-        expires_buf.copy_from_slice(
-            &signed_message[M::EXPIRES_AT_OFFSET..M::EXPIRES_AT_OFFSET + M::EXPIRES_AT_LEN],
-        );
-        let msg_expires_at = i64::from_le_bytes(expires_buf);
-
-        // The signed message must match the ix args bit-for-bit.
-        // We don't compare msg_recv_id to source_id directly: we hash
-        // (source_id || agent || amount || expires_at) into the message; receivable_id
-        // CAN equal source_id when the source defines it that way, but in general
-        // the signed receivable_id is what's authoritative, and source_id is the
-        // PDA seed we use locally. We still require source_id to be consistent.
-        require!(
-            msg_recv_id == source_id.as_ref(),
-            OracleError::Ed25519Missing
-        );
-        require!(
-            msg_agent == ctx.accounts.agent.key().as_ref(),
-            OracleError::Ed25519Missing
-        );
-        require!(msg_amount == amount, OracleError::Ed25519Missing);
-        require!(msg_expires_at == expires_at, OracleError::Ed25519Missing);
+        require!(decoded.amount == amount, OracleError::Ed25519Missing);
+        require!(decoded.expires_at == expires_at, OracleError::Ed25519Missing);
 
         // (4) Cap enforcement on the AllowedSigner.
         let signer_acc = &mut ctx.accounts.allowed_signer;
@@ -299,12 +272,34 @@ pub mod credmesh_receivable_oracle {
         Ok(())
     }
 
-    /// Rotate the governance authority itself. Use with extreme care — once
-    /// changed, only the new governance can rotate it back. Gated by current
-    /// governance.
-    pub fn set_governance(ctx: Context<SetGovernance>, new_governance: Pubkey) -> Result<()> {
+    /// Two-step governance handover, step 1: current governance proposes a new
+    /// governance pubkey. Step 2 is `accept_governance` called by the new key.
+    /// This prevents single-tx takeover via compromised governance key.
+    pub fn propose_governance(
+        ctx: Context<ProposeGovernance>,
+        new_governance: Pubkey,
+    ) -> Result<()> {
+        require_keys_neq!(new_governance, Pubkey::default(), OracleError::NotGovernance);
         let config = &mut ctx.accounts.config;
-        config.governance = new_governance;
+        config.pending_governance = Some(new_governance);
+        Ok(())
+    }
+
+    /// Two-step governance handover, step 2: the proposed new authority signs
+    /// to accept. Cancellation: current governance calls `propose_governance`
+    /// with the current authority's pubkey to clear the pending slot.
+    pub fn accept_governance(ctx: Context<AcceptGovernance>) -> Result<()> {
+        let config = &mut ctx.accounts.config;
+        let pending = config
+            .pending_governance
+            .ok_or(OracleError::NotGovernance)?;
+        require_keys_eq!(
+            ctx.accounts.new_governance.key(),
+            pending,
+            OracleError::NotGovernance
+        );
+        config.governance = pending;
+        config.pending_governance = None;
         Ok(())
     }
 }
@@ -456,13 +451,24 @@ pub struct SetReputationWriter<'info> {
 }
 
 #[derive(Accounts)]
-pub struct SetGovernance<'info> {
+pub struct ProposeGovernance<'info> {
     pub governance: Signer<'info>,
     #[account(
         mut,
         seeds = [ORACLE_CONFIG_SEED],
         bump = config.bump,
         constraint = config.governance == governance.key() @ OracleError::NotGovernance
+    )]
+    pub config: Account<'info, OracleConfig>,
+}
+
+#[derive(Accounts)]
+pub struct AcceptGovernance<'info> {
+    pub new_governance: Signer<'info>,
+    #[account(
+        mut,
+        seeds = [ORACLE_CONFIG_SEED],
+        bump = config.bump
     )]
     pub config: Account<'info, OracleConfig>,
 }

--- a/programs/credmesh-receivable-oracle/src/state.rs
+++ b/programs/credmesh-receivable-oracle/src/state.rs
@@ -8,6 +8,10 @@ pub const MAX_STALENESS_SLOTS: u64 = 5_400;
 pub struct OracleConfig {
     pub bump: u8,
     pub governance: Pubkey,
+    /// Two-step governance handover: set by `propose_governance`, accepted by
+    /// `accept_governance` from the new authority. Prevents single-tx takeover
+    /// if the current governance key is compromised.
+    pub pending_governance: Option<Pubkey>,
     pub worker_authority: Pubkey,
     pub worker_max_per_tx: u64,
     pub worker_max_per_period: u64,
@@ -30,6 +34,7 @@ impl OracleConfig {
     pub const SIZE: usize = 8
         + 1
         + 32 * 3
+        + (1 + 32)        // pending_governance: Option<Pubkey>
         + 8 * 5
         + 1 + 4 + 8 + 8 + 4
         + 32;

--- a/programs/credmesh-reputation/src/errors.rs
+++ b/programs/credmesh-reputation/src/errors.rs
@@ -12,4 +12,8 @@ pub enum ReputationError {
     NotOriginalSigner,
     #[msg("Math overflow")]
     MathOverflow,
+    #[msg("OracleConfig cross-program account did not match expected derivation")]
+    OracleConfigMismatch,
+    #[msg("Instruction not implemented in v1")]
+    NotImplemented,
 }

--- a/programs/credmesh-reputation/src/lib.rs
+++ b/programs/credmesh-reputation/src/lib.rs
@@ -61,7 +61,7 @@ pub mod credmesh_reputation {
             &credmesh_shared::program_ids::RECEIVABLE_ORACLE,
             &oracle_config_pda,
         )
-        .map_err(|_| ReputationError::MathOverflow)?;
+        .map_err(|_| ReputationError::OracleConfigMismatch)?;
 
         // (2) Always: append to digest + bump count + emit event.
         let attestor = ctx.accounts.attestor.key();
@@ -99,9 +99,9 @@ pub mod credmesh_reputation {
                 ReputationError::InvalidScore
             );
 
-            // EMA update with N = EMA_WINDOW. score is u8 0..100; multiply by
+            // EMA update with N = EMA_WINDOW. score is u8 0..100; scaled by
             // 1e18 to get the 18-decimal representation, then EMA.
-            let score_scaled = (input.score as u128).saturating_mul(1_000_000_000_000_000_000u128);
+            let score_scaled = (input.score as u128).saturating_mul(credmesh_shared::SCORE_SCALE);
             let n = EMA_WINDOW as u128;
             // ema_new = (ema_old * (n - 1) + new_score) / n
             let ema_old = reputation.score_ema;
@@ -143,18 +143,16 @@ pub mod credmesh_reputation {
     }
 
     pub fn append_response(
-        ctx: Context<AppendResponse>,
-        feedback_index: u64,
-        response_uri: String,
-        response_hash: [u8; 32],
+        _ctx: Context<AppendResponse>,
+        _feedback_index: u64,
+        _response_uri: String,
+        _response_hash: [u8; 32],
     ) -> Result<()> {
-        let _ = (ctx, feedback_index, response_uri, response_hash);
-        Ok(())
+        Err(ReputationError::NotImplemented.into())
     }
 
-    pub fn revoke_feedback(ctx: Context<RevokeFeedback>, feedback_index: u64) -> Result<()> {
-        let _ = (ctx, feedback_index);
-        Ok(())
+    pub fn revoke_feedback(_ctx: Context<RevokeFeedback>, _feedback_index: u64) -> Result<()> {
+        Err(ReputationError::NotImplemented.into())
     }
 }
 

--- a/programs/credmesh-reputation/src/state.rs
+++ b/programs/credmesh-reputation/src/state.rs
@@ -2,7 +2,6 @@ use anchor_lang::prelude::*;
 
 pub use credmesh_shared::seeds::REPUTATION_SEED;
 
-pub const SCORE_DECIMALS: u8 = 18;
 pub const EMA_WINDOW: u64 = 50;
 
 #[account]

--- a/programs/credmesh-shared/src/cross_program.rs
+++ b/programs/credmesh-shared/src/cross_program.rs
@@ -11,7 +11,6 @@
 /// Forgetting any one of these is the Wormhole / Cashio / similar-class bug.
 /// All four are wrapped together below.
 use anchor_lang::prelude::*;
-use anchor_lang::Discriminator;
 
 #[derive(Clone, Copy, Debug)]
 pub enum CrossProgramReadError {
@@ -35,7 +34,7 @@ pub fn read_cross_program_account<T>(
     expected_address: &Pubkey,
 ) -> std::result::Result<T, CrossProgramReadError>
 where
-    T: AccountDeserialize + Discriminator,
+    T: AccountDeserialize,
 {
     if info.owner != expected_owner {
         return Err(CrossProgramReadError::OwnerMismatch);
@@ -46,14 +45,10 @@ where
     let data = info
         .try_borrow_data()
         .map_err(|_| CrossProgramReadError::Deserialize)?;
-    if data.len() < 8 {
-        return Err(CrossProgramReadError::DiscriminatorMismatch);
-    }
-    if data[..8] != T::DISCRIMINATOR {
-        return Err(CrossProgramReadError::DiscriminatorMismatch);
-    }
+    // `try_deserialize` validates the 8-byte discriminator and advances past it;
+    // we don't pre-check here because doing both would duplicate the validation.
     let mut slice = &data[..];
-    T::try_deserialize(&mut slice).map_err(|_| CrossProgramReadError::Deserialize)
+    T::try_deserialize(&mut slice).map_err(|_| CrossProgramReadError::DiscriminatorMismatch)
 }
 
 /// Re-derive a PDA from a slice of seed parts under a program ID.

--- a/programs/credmesh-shared/src/lib.rs
+++ b/programs/credmesh-shared/src/lib.rs
@@ -14,12 +14,16 @@ pub mod seeds {
     pub const POOL_SEED: &[u8] = b"pool";
     pub const ADVANCE_SEED: &[u8] = b"advance";
     pub const CONSUMED_SEED: &[u8] = b"consumed";
-    pub const TREASURY_SEED: &[u8] = b"treasury";
     pub const REPUTATION_SEED: &[u8] = b"agent_reputation";
     pub const RECEIVABLE_SEED: &[u8] = b"receivable";
     pub const ALLOWED_SIGNER_SEED: &[u8] = b"allowed_signer";
     pub const ORACLE_CONFIG_SEED: &[u8] = b"oracle_config";
 }
+
+/// 18-decimal scalar for `score_ema` (mirrors EVM 18-decimal arithmetic).
+pub const SCORE_SCALE: u128 = 1_000_000_000_000_000_000;
+
+pub const SECONDS_PER_DAY: u64 = 86_400;
 
 pub mod program_ids {
     use anchor_lang::prelude::Pubkey;
@@ -71,6 +75,40 @@ pub mod ed25519_message {
     pub const EXPIRES_AT_LEN: usize = 8;
     pub const NONCE_OFFSET: usize = 80;
     pub const NONCE_LEN: usize = 16;
+
+    /// Typed view of a 96-byte ed25519-signed receivable. Single source of truth
+    /// for the layout — both escrow and receivable-oracle decode via this.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct SignedReceivable {
+        pub receivable_id: [u8; 32],
+        pub agent: [u8; 32],
+        pub amount: u64,
+        pub expires_at: i64,
+        pub nonce: [u8; 16],
+    }
+
+    pub fn decode(msg: &[u8]) -> Option<SignedReceivable> {
+        if msg.len() != TOTAL_LEN {
+            return None;
+        }
+        let mut receivable_id = [0u8; 32];
+        receivable_id.copy_from_slice(&msg[RECEIVABLE_ID_OFFSET..RECEIVABLE_ID_OFFSET + RECEIVABLE_ID_LEN]);
+        let mut agent = [0u8; 32];
+        agent.copy_from_slice(&msg[AGENT_OFFSET..AGENT_OFFSET + AGENT_LEN]);
+        let mut amount_buf = [0u8; 8];
+        amount_buf.copy_from_slice(&msg[AMOUNT_OFFSET..AMOUNT_OFFSET + AMOUNT_LEN]);
+        let mut expires_buf = [0u8; 8];
+        expires_buf.copy_from_slice(&msg[EXPIRES_AT_OFFSET..EXPIRES_AT_OFFSET + EXPIRES_AT_LEN]);
+        let mut nonce = [0u8; 16];
+        nonce.copy_from_slice(&msg[NONCE_OFFSET..NONCE_OFFSET + NONCE_LEN]);
+        Some(SignedReceivable {
+            receivable_id,
+            agent,
+            amount: u64::from_le_bytes(amount_buf),
+            expires_at: i64::from_le_bytes(expires_buf),
+            nonce,
+        })
+    }
 }
 
 /// Field offsets inside an MPL Core `BaseAssetV1` account's data buffer.

--- a/ts/server/src/auth.ts
+++ b/ts/server/src/auth.ts
@@ -24,6 +24,14 @@ import bs58 from "bs58";
 const SIWS_DOMAIN = process.env.CREDMESH_DOMAIN ?? "credmesh.xyz";
 const TIMESTAMP_TOLERANCE_MS = 10 * 60 * 1000; // ±10 min
 const NONCE_TTL_MS = 5 * 60 * 1000;
+const NONCE_GC_PROBABILITY = 0.05;
+const NONCE_MAX_SIZE = 100_000;
+
+// CAIP-2 chain IDs (genesis hash prefixes). Required for Phantom anti-phishing UI.
+const CAIP2_CHAIN_ID: Record<"mainnet-beta" | "devnet", string> = {
+  "mainnet-beta": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+  devnet: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1S5jJUrdiJzMv",
+};
 
 export interface SiwsPayload {
   domain: string;
@@ -63,7 +71,9 @@ class NonceStore {
   private nonces = new Map<string, { issuedAt: number; address: string }>();
 
   issue(address: string): string {
-    this.gc();
+    if (this.nonces.size >= NONCE_MAX_SIZE || Math.random() < NONCE_GC_PROBABILITY) {
+      this.gc();
+    }
     const nonce = randomNonce(16);
     this.nonces.set(nonce, { issuedAt: Date.now(), address });
     return nonce;
@@ -81,10 +91,13 @@ class NonceStore {
     return true;
   }
 
+  // Map preserves insertion order; iterate from the front and break on the
+  // first entry that's still within TTL.
   private gc(): void {
-    const now = Date.now();
+    const cutoff = Date.now() - NONCE_TTL_MS;
     for (const [nonce, entry] of this.nonces) {
-      if (now - entry.issuedAt > NONCE_TTL_MS) this.nonces.delete(nonce);
+      if (entry.issuedAt > cutoff) break;
+      this.nonces.delete(nonce);
     }
   }
 }
@@ -146,7 +159,7 @@ export const authMiddleware = createMiddleware<{
     statement: "Authenticate to CredMesh",
     uri: requestUri,
     version: "1",
-    chainId: `solana:${cluster}`,
+    chainId: CAIP2_CHAIN_ID[cluster],
     nonce,
     issuedAt: timestamp,
     expirationTime,


### PR DESCRIPTION
## Summary

Applies the convergent findings from a four-reviewer pass over the overnight implementation work (reuse, quality, efficiency, skills-based). Also lands `CLAUDE.md` for future Claude Code sessions.

## What's in this PR

### Correctness
- **`SignedReceivable::decode()` helper** in `credmesh_shared::ed25519_message`. Both escrow `request_advance` and oracle `ed25519_record_receivable` decoded the same 96-byte layout independently — silent layout-drift risk. Now single source of truth.
- **`InsufficientPayment` error** added so `claim_and_settle` distinguishes user error (paid < total_owed) from internal sum-invariant breach. Was reusing `WaterfallSumMismatch` for both.
- **`OracleConfigMismatch` + `NotImplemented`** errors. `give_feedback`'s cross-program-read failure was mapping to `MathOverflow` (semantically wrong). `append_response` and `revoke_feedback` now return `NotImplemented` instead of silently `Ok(())` — clients couldn't distinguish stub from success.
- **Two-step governance handover** for the receivable oracle. `propose_governance` (current authority) + `accept_governance` (new authority signs). Closes the single-tx-takeover vector that `set_governance` had.
- **CAIP-2 chainId in SIWS**. Was emitting `solana:mainnet-beta` (human string); now uses canonical CAIP-2 genesis-hash prefixes per Phantom anti-phishing UI requirements.

### Cleanup
- Promoted magic numbers to named constants (`SCORE_SCALE`, `SECONDS_PER_DAY`, `LATE_PENALTY_BPS_PER_DAY`).
- Removed dead constants (`TREASURY_SEED`, `SCORE_DECIMALS`).
- Removed redundant manual discriminator pre-check in `cross_program::read_cross_program_account` — Anchor 0.30's `try_deserialize` already validates it; doing both was duplicate validation that masked a Cashio-class refactor footgun.

### Performance
- `NonceStore.gc()` now lazy (5% probability per issue + size cap), with insertion-order iteration that breaks on first unexpired entry. Previously O(n) full scan on every issue.

### New
- **`CLAUDE.md`** at repo root. Mirrors the EVM credmesh CLAUDE.md format. Future sessions land with the right read order, conventions, and load-bearing invariants documented.

## Deferred (worth follow-up PRs)

The skills review surfaced four bigger refactors not landed here:

1. `#[derive(InitSpace)]` migration for all 8 `#[account]` structs (replaces hand-rolled `SIZE` consts)
2. `emit_cpi!` migration for `NewFeedback` to defend against the 10 KB log-truncation cap
3. Anchor 0.30 `seeds::program` for typed cross-program `Account` reads (replaces UncheckedAccount + manual deserialize at 3 sites)
4. Token-2022 forward-compat via `anchor_spl::token_interface`

Each is small but focused; better as standalone PRs than bundled here.

## Test plan

- [ ] `anchor build` succeeds (placeholders are valid 32-byte pubkeys; first build will surface any 0.30 syntax issues)
- [ ] `cargo check --workspace --locked` clean
- [ ] Bankrun tests scaffolded in `tests/bankrun/` — bodies still TODO until IDL is generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)