### PR TITLE
reputation: emit NewFeedback via emit_cpi! (#3)

### DIFF
--- a/programs/credmesh-reputation/src/lib.rs
+++ b/programs/credmesh-reputation/src/lib.rs
@@ -124,7 +124,11 @@ pub mod credmesh_reputation {
             reputation.last_event_slot = slot;
         }
 
-        emit!(NewFeedback {
+        // Issue #3: emit via CPI inner-instruction so the event survives
+        // a noisy-log adversary tx that pushes the LogCollector past 10 KB.
+        // NewFeedback carries variable-length fields (feedback_uri up to 200 B)
+        // and is the only event in this program at risk of truncation.
+        emit_cpi!(NewFeedback {
             agent_asset: reputation.agent_asset,
             feedback_index,
             attestor,
@@ -176,6 +180,7 @@ pub struct InitReputation<'info> {
     pub system_program: Program<'info, System>,
 }
 
+#[event_cpi]
 #[derive(Accounts)]
 pub struct GiveFeedback<'info> {
     pub attestor: Signer<'info>,


### PR DESCRIPTION
Closes #3.

## Summary

- Add `#[event_cpi]` to the `GiveFeedback` accounts struct (auto-injects the event-authority PDA + program account).
- Swap `emit!(NewFeedback)` to `emit_cpi!(NewFeedback)` in `give_feedback`.
- Other events in this program (`ReputationInitialized`, `FeedbackResponse`, `FeedbackRevoked`) carry only fixed-size fields and stay on plain `emit!`.

## Why

Solana's `LogCollector` truncates at exactly 10 KB per transaction. `NewFeedback` carries `feedback_uri: String` (max 200 B) plus 3× `[u8; 32]`, 2× `Pubkey`, `score_ema_after: u128` — ~400 B payload, ~540 chars base64-encoded. An attacker can prepend a noisy spam-log instruction to push `NewFeedback` past the 10 KB cap and silently drop the event, leaving on-chain reputation state diverged from any indexer that scrapes logs.

CPI inner-instruction data lives in transaction metadata, not the log buffer, so `emit_cpi!` defeats this attack at a cost of ~1k extra CU per `give_feedback`.

## Off-chain impact

Indexers must read `NewFeedback` via `getTransaction` → `meta.innerInstructions` (Anchor-CPI-emitted events appear as a self-CPI to the program with the event data as instruction data). The `ReputationInitialized` / `FeedbackResponse` / `FeedbackRevoked` paths are unchanged.

## Files

- `programs/credmesh-reputation/src/lib.rs` — `#[event_cpi]` attr added; `emit!` → `emit_cpi!` for `NewFeedback`.

## Test plan

- [ ] `anchor build` succeeds (cannot verify in this env — codebase is not compile-verified yet per CLAUDE.md; minor 0.30 fixes may surface)
- [ ] Day 3 of this track adds a Bankrun fixture proving the event survives a noisy-log adversary tx that would have truncated a plain `emit!`

## Track-B context

Day 1 of EPIC #9 Track B (reputation program). Day 2 = InitSpace for `AgentReputation` (#2 reputation portion). Day 3 = bankrun fixture. When this PR merges, writes the `emit_cpi_merged` status file that unblocks Track C's day 4 (#4 typed cross-program reads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)