### PR TITLE
reputation: derive InitSpace for AgentReputation (#2 reputation portion)

### DIFF
--- a/programs/credmesh-reputation/src/lib.rs
+++ b/programs/credmesh-reputation/src/lib.rs
@@ -168,7 +168,7 @@ pub struct InitReputation<'info> {
     #[account(
         init,
         payer = payer,
-        space = AgentReputation::SIZE,
+        space = 8 + AgentReputation::INIT_SPACE,
         seeds = [REPUTATION_SEED, agent_asset.key().as_ref()],
         bump
     )]

--- a/programs/credmesh-reputation/src/state.rs
+++ b/programs/credmesh-reputation/src/state.rs
@@ -6,6 +6,7 @@ pub const SCORE_DECIMALS: u8 = 18;
 pub const EMA_WINDOW: u64 = 50;
 
 #[account]
+#[derive(InitSpace)]
 pub struct AgentReputation {
     pub bump: u8,
     pub agent_asset: Pubkey,
@@ -14,10 +15,6 @@ pub struct AgentReputation {
     pub score_ema: u128,
     pub default_count: u32,
     pub last_event_slot: u64,
-}
-
-impl AgentReputation {
-    pub const SIZE: usize = 8 + 1 + 32 + 8 + 32 + 16 + 4 + 8 + 32;
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone)]


### PR DESCRIPTION
Partial fix for #2 — reputation portion only. Escrow + oracle account migrations are scheduled on other tracks per EPIC #9.

## Summary

- Add `#[derive(InitSpace)]` to `AgentReputation` in `programs/credmesh-reputation/src/state.rs`.
- Drop the manual `pub const SIZE` (was `8 + 1 + 32 + 8 + 32 + 16 + 4 + 8 + 32`).
- `init_reputation` accounts struct now uses `space = 8 + AgentReputation::INIT_SPACE`.

## Why

`AgentReputation::SIZE` was a hand-rolled byte-count with 32 trailing padding bytes for unspecified future use. The other tracked structs in the workspace had a similar pattern, and at least one of them (`Pool` / `PendingParams` per the issue body) hides an undercount that the padding masks. Switching to derived `INIT_SPACE` removes both the drift risk and the maintenance burden of editing the const every time a field is added.

## Layout impact

`AgentReputation` is fixed-size — no `String`, no `Vec`, so no `#[max_len(...)]` annotations were needed. Computed bytes:

| field            | bytes |
|------------------|-------|
| bump             | 1     |
| agent_asset      | 32    |
| feedback_count   | 8     |
| feedback_digest  | 32    |
| score_ema        | 16    |
| default_count    | 4     |
| last_event_slot  | 8     |
| **INIT_SPACE**   | **101** |
| + 8 discriminator| **109** |

Old allocation was 141 (109 + 32 padding). The layout is locked by the 8004-shape rolling-digest design and is not expected to grow within v1.

## Files

- `programs/credmesh-reputation/src/state.rs` — derive added; `SIZE` const removed.
- `programs/credmesh-reputation/src/lib.rs` — single `space = ...::SIZE` site updated.

## Out of scope

- `Pool`, `Advance`, `ConsumedPayment`, `PendingParams`, `FeeCurve` in `credmesh-escrow` — Track C owns.
- `OracleConfig`, `Receivable`, `AllowedSigner` in `credmesh-receivable-oracle` — assigned per the EPIC.

## Test plan

- [ ] `anchor build` succeeds (cannot verify in this env — codebase not compile-verified yet per CLAUDE.md)
- [ ] Bankrun `init_reputation` test (when Track A delivers a working build) confirms allocation succeeds and the account deserializes round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)