### PR TITLE
Track C day 4 — typed cross-program reads (issue #4)

### DIFF
--- a/programs/credmesh-escrow/src/lib.rs
+++ b/programs/credmesh-escrow/src/lib.rs
@@ -216,43 +216,21 @@ pub mod credmesh_escrow {
             _ => error!(CredmeshError::AgentBindingMismatch),
         })?;
 
-        // (2) Read AgentReputation cross-program.
-        let reputation_pda = credmesh_shared::cross_program::derive_pda(
-            &[
-                credmesh_reputation::REPUTATION_SEED,
-                ctx.accounts.agent_asset.key.as_ref(),
-            ],
-            &credmesh_shared::program_ids::REPUTATION,
-        );
-        let reputation = credmesh_shared::cross_program::read_cross_program_account::<
-            credmesh_reputation::AgentReputation,
-        >(
-            &ctx.accounts.agent_reputation_pda.to_account_info(),
-            &credmesh_shared::program_ids::REPUTATION,
-            &reputation_pda,
-        )
-        .map_err(|_| error!(CredmeshError::ReputationPdaMismatch))?;
+        // (2) Read AgentReputation cross-program. Issue #4: typed `Account` with
+        // `seeds::program` runs Anchor's owner+address+discriminator+deserialize
+        // verify automatically — no handler-side manual read.
+        let reputation = &ctx.accounts.agent_reputation_pda;
 
         // (3) Read Receivable cross-program (Worker path) OR verify ed25519
-        // signed receivable (Ed25519/X402 paths).
+        // signed receivable (Ed25519/X402 paths). Issue #4: same Anchor-typed
+        // pattern; the Worker path resolves the `Option<Account>` to `Some`.
         let (receivable_amount, receivable_expires_at, source_signer) = match kind {
             credmesh_shared::SourceKind::Worker => {
-                let receivable_pda = credmesh_shared::cross_program::derive_pda(
-                    &[
-                        credmesh_receivable_oracle::RECEIVABLE_SEED,
-                        ctx.accounts.agent.key.as_ref(),
-                        receivable_id.as_ref(),
-                    ],
-                    &credmesh_shared::program_ids::RECEIVABLE_ORACLE,
-                );
-                let receivable = credmesh_shared::cross_program::read_cross_program_account::<
-                    credmesh_receivable_oracle::Receivable,
-                >(
-                    &ctx.accounts.receivable_pda.to_account_info(),
-                    &credmesh_shared::program_ids::RECEIVABLE_ORACLE,
-                    &receivable_pda,
-                )
-                .map_err(|_| error!(CredmeshError::ReceivablePdaMismatch))?;
+                let receivable = ctx
+                    .accounts
+                    .receivable_pda
+                    .as_ref()
+                    .ok_or(error!(CredmeshError::ReceivablePdaMismatch))?;
 
                 let staleness =
                     slot.saturating_sub(receivable.last_updated_slot);
@@ -952,15 +930,28 @@ pub struct RequestAdvance<'info> {
     /// Handler re-derives ["agent_identity", agent_asset.key()] under MPL_AGENT_REGISTRY
     /// and asserts equality. Required to prove agent_asset is registered as an Agent.
     pub agent_identity: UncheckedAccount<'info>,
-    /// CHECK: AgentReputation PDA (owned by credmesh-reputation).
-    /// Handler must: verify owner == credmesh_shared::program_ids::REPUTATION,
-    /// re-derive [REPUTATION_SEED, agent_asset.key()], check 8-byte discriminator,
-    /// then deserialize.
-    pub agent_reputation_pda: UncheckedAccount<'info>,
-    /// CHECK: Receivable PDA (owned by credmesh-receivable-oracle), required iff source_kind=Worker.
-    /// For ed25519 / x402 paths the handler verifies via instruction-introspection
-    /// instead of reading this account; pass any read-only pubkey (e.g., system_program).
-    pub receivable_pda: UncheckedAccount<'info>,
+    /// AgentReputation PDA owned by credmesh-reputation. Issue #4: Anchor's
+    /// typed Account + seeds::program does the four-step verify (owner →
+    /// address → discriminator → deserialize) declaratively. The handler
+    /// reads `score_ema` / `default_count` directly off this typed account.
+    #[account(
+        seeds = [credmesh_shared::seeds::REPUTATION_SEED, agent_asset.key().as_ref()],
+        seeds::program = credmesh_reputation::ID,
+        bump,
+    )]
+    pub agent_reputation_pda: Account<'info, credmesh_reputation::AgentReputation>,
+    /// Receivable PDA owned by credmesh-receivable-oracle, required iff
+    /// `source_kind = Worker`. For Ed25519 / X402 paths the handler verifies
+    /// via instruction-introspection instead of reading this account, so the
+    /// caller passes `None` (encoded as a missing account); a typed `Account`
+    /// without `Option` would fail the discriminator check there. Anchor
+    /// runs the four-step verify on `Some` only (issue #4).
+    #[account(
+        seeds = [credmesh_shared::seeds::RECEIVABLE_SEED, agent.key().as_ref(), receivable_id.as_ref()],
+        seeds::program = credmesh_receivable_oracle::ID,
+        bump,
+    )]
+    pub receivable_pda: Option<Account<'info, credmesh_receivable_oracle::Receivable>>,
     /// CHECK: Optional ExecutiveProfileV1 PDA (MPL Agent Tools) for delegate path.
     /// Pass `None` (Anchor encodes as missing) when agent.key() is the asset's owner.
     pub executive_profile: Option<UncheckedAccount<'info>>,

--- a/programs/credmesh-reputation/src/lib.rs
+++ b/programs/credmesh-reputation/src/lib.rs
@@ -50,18 +50,9 @@ pub mod credmesh_reputation {
         // gate is purely the writer-authority equality check below.
         // v1.5 will move the per-period state to a dedicated ReputationConfig
         // PDA owned by credmesh-reputation. See V1_ACCEPTANCE.md.
-        let oracle_config_pda = credmesh_shared::cross_program::derive_pda(
-            &[credmesh_receivable_oracle::ORACLE_CONFIG_SEED],
-            &credmesh_shared::program_ids::RECEIVABLE_ORACLE,
-        );
-        let oracle_config = credmesh_shared::cross_program::read_cross_program_account::<
-            credmesh_receivable_oracle::OracleConfig,
-        >(
-            &ctx.accounts.oracle_config.to_account_info(),
-            &credmesh_shared::program_ids::RECEIVABLE_ORACLE,
-            &oracle_config_pda,
-        )
-        .map_err(|_| ReputationError::MathOverflow)?;
+        // Issue #4: typed `Account` + `seeds::program` runs the four-step
+        // verify in the accounts struct; no handler-side manual read needed.
+        let oracle_config = &ctx.accounts.oracle_config;
 
         // (2) Always: append to digest + bump count + emit event.
         let attestor = ctx.accounts.attestor.key();
@@ -192,10 +183,16 @@ pub struct GiveFeedback<'info> {
         bump = reputation.bump
     )]
     pub reputation: Account<'info, AgentReputation>,
-    /// CHECK: OracleConfig PDA (owned by credmesh-receivable-oracle).
-    /// Handler re-derives [ORACLE_CONFIG_SEED] under RECEIVABLE_ORACLE program ID
-    /// and verifies the discriminator.
-    pub oracle_config: UncheckedAccount<'info>,
+    /// OracleConfig PDA owned by credmesh-receivable-oracle. Issue #4: typed
+    /// `Account` with `seeds::program` runs Anchor's owner+address+discriminator+
+    /// deserialize verify automatically. Read for the writer-authority gate
+    /// (`reputation_writer_authority` + `reputation_max_per_tx_score`).
+    #[account(
+        seeds = [credmesh_shared::seeds::ORACLE_CONFIG_SEED],
+        seeds::program = credmesh_receivable_oracle::ID,
+        bump,
+    )]
+    pub oracle_config: Account<'info, credmesh_receivable_oracle::OracleConfig>,
 }
 
 #[derive(Accounts)]


### PR DESCRIPTION
Closes #4.

Migrates three `UncheckedAccount` + manual `read_cross_program_account` sites to declarative typed `Account<'info, T>` reads using Anchor's `seeds::program` to re-derive the foreign PDA. Anchor performs the same four-step verify (owner → address → discriminator → deserialize), so the handler-side manual reads drop entirely.

## Sites migrated

| Site | Field | Type | seeds::program |
|---|---|---|---|
| `escrow / RequestAdvance` | `agent_reputation_pda` | `Account<'info, credmesh_reputation::AgentReputation>` | `credmesh_reputation::ID` |
| `escrow / RequestAdvance` | `receivable_pda` | `Option<Account<'info, credmesh_receivable_oracle::Receivable>>` | `credmesh_receivable_oracle::ID` |
| `reputation / GiveFeedback` | `oracle_config` | `Account<'info, credmesh_receivable_oracle::OracleConfig>` | `credmesh_receivable_oracle::ID` |

## Notes

- **`receivable_pda` is `Option<>` wrapped.** Worker path requires `Some`; Ed25519 / X402 paths verify via instruction-introspection and the caller passes `None` (encoded as missing). A typed `Account` without `Option` would force callers to provide a real Receivable PDA even when the handler ignores it, and a typed read would fail the discriminator check on the placeholder accounts the off-chain client used to pass.
- The Worker handler now does `ctx.accounts.receivable_pda.as_ref().ok_or(error!(CredmeshError::ReceivablePdaMismatch))?` to raise when the caller fails to provide the required PDA on the Worker path.
- The shared `cross_program::read_cross_program_account` helper stays in place per issue #4 acceptance ("keep the helper for cases where `seeds::program` doesn't fit"). Currently unused after this PR but reserved for variable-seed-path cases.
- Prior `CredmeshError::ReputationPdaMismatch` / `ReceivablePdaMismatch` paths are now raised by Anchor's standard error codes (`AccountOwnedByWrongProgram` / `AccountDiscriminatorMismatch` / `ConstraintSeeds`). The variants are kept in `errors.rs` to avoid shifting the discriminants of subsequent variants.
- Track B's `AgentReputation` typed export (PR #12) is in scope via the `cpi` feature on `credmesh-reputation` — the type is already imported by name in the prior manual-read path.

## Acceptance (issue #4)

- [x] All three sites migrated to declarative typed reads
- [x] Manual handler-side `read_cross_program_account` calls removed where superseded
- [ ] `anchor build` succeeds (Track A devnet build environment)
- [ ] Bankrun cross-program-read tests pass (Track D)

## Test plan

- [ ] `anchor build` against the Day-1 toolchain image
- [ ] Re-run Track D's `request_advance_worker.test.ts` — typed read should still resolve, fixtures unchanged
- [ ] Re-run Track D's `request_advance_ed25519` (when it lands) — confirm `None` path works
- [ ] Re-run reputation `give_feedback_writer_gating.test.ts` — confirm the typed `oracle_config` read still gates score updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)