### PR TITLE
fix: audit MED findings (#3 PDA namespace, #4 memo loop cap, #5 FeeCurve validation)

### DIFF
--- a/crates/credmesh-shared/src/ix_introspection.rs
+++ b/crates/credmesh-shared/src/ix_introspection.rs
@@ -116,21 +116,27 @@ pub fn verify_prev_ed25519(
     Ok((signed_pubkey, signed_message))
 }
 
+/// Hard upper bound on instructions scanned by `require_memo_nonce`. Solana
+/// transactions are capped at ~64 top-level instructions in practice (the
+/// 1232-byte tx-size limit binds before this), so 64 is permissive without
+/// being unbounded. Audit-MED #4 fix: when v1.5 makes `claim_and_settle`
+/// permissionless, a malicious cranker could pad the tx with no-ops to
+/// exhaust compute before reaching the Memo; an explicit cap defends now.
+const MAX_IX_SCAN: usize = 64;
+
 /// Find a Memo program instruction in the current tx whose data matches the
-/// expected nonce bytes. Searches all instructions in the tx (memo placement
-/// is not constrained relative to the calling ix).
+/// expected nonce bytes. Searches up to `MAX_IX_SCAN` top-level instructions
+/// (memo placement is not constrained relative to the calling ix).
 pub fn require_memo_nonce(
     sysvar_instructions_ai: &AccountInfo<'_>,
     expected_nonce: &[u8],
 ) -> std::result::Result<(), IxIntrospectionError> {
-    let mut idx = 0usize;
-    loop {
+    for idx in 0..MAX_IX_SCAN {
         match load_instruction_at_checked(idx, sysvar_instructions_ai) {
             Ok(ix) => {
                 if ix.program_id == MEMO && ix.data == expected_nonce {
                     return Ok(());
                 }
-                idx += 1;
             }
             Err(_) => break,
         }

--- a/programs/credmesh-escrow/src/errors.rs
+++ b/programs/credmesh-escrow/src/errors.rs
@@ -56,4 +56,6 @@ pub enum CredmeshError {
     WaterfallSumMismatch,
     #[msg("Late days exceed maximum cap")]
     LateDaysExceeded,
+    #[msg("FeeCurve violates ordering or BPS-bound invariants — see FeeCurve::validate")]
+    InvalidFeeCurve,
 }

--- a/programs/credmesh-escrow/src/lib.rs
+++ b/programs/credmesh-escrow/src/lib.rs
@@ -23,6 +23,8 @@ pub mod credmesh_escrow {
             CredmeshError::AdvanceExceedsCap
         );
         require!(params.timelock_seconds >= 0, CredmeshError::MathOverflow);
+        // Audit-MED #5: reject malformed fee curves at construction.
+        params.fee_curve.validate()?;
 
         let pool = &mut ctx.accounts.pool;
         pool.bump = ctx.bumps.pool;
@@ -591,6 +593,12 @@ pub mod credmesh_escrow {
     }
 
     pub fn propose_params(ctx: Context<ProposeParams>, params: PendingParams) -> Result<()> {
+        // Audit-MED #5: validate the proposed curve BEFORE staging it under
+        // timelock. Catching this at propose-time (rather than execute-time)
+        // gives governance the full timelock window to fix a bad submission
+        // and keeps execute_params a pure timelock check.
+        params.fee_curve.validate()?;
+
         let now = Clock::get()?.unix_timestamp;
         let pool = &mut ctx.accounts.pool;
         let mut params = params;

--- a/programs/credmesh-escrow/src/lib.rs
+++ b/programs/credmesh-escrow/src/lib.rs
@@ -946,8 +946,12 @@ pub struct RequestAdvance<'info> {
     /// caller passes `None` (encoded as a missing account); a typed `Account`
     /// without `Option` would fail the discriminator check there. Anchor
     /// runs the four-step verify on `Some` only (issue #4).
+    /// Audit-MED #3 fix: the source_kind byte (`[0]` for Worker) is part of
+    /// the receivable PDA seed, so the address Anchor verifies here can only
+    /// resolve to a Worker-created receivable — an ed25519-attested receivable
+    /// (kind=1/2) lives at a different address and cannot pass this gate.
     #[account(
-        seeds = [credmesh_shared::seeds::RECEIVABLE_SEED, agent.key().as_ref(), receivable_id.as_ref()],
+        seeds = [credmesh_shared::seeds::RECEIVABLE_SEED, &[0u8], agent.key().as_ref(), receivable_id.as_ref()],
         seeds::program = credmesh_receivable_oracle::ID,
         bump,
     )]

--- a/programs/credmesh-escrow/src/state.rs
+++ b/programs/credmesh-escrow/src/state.rs
@@ -48,6 +48,39 @@ pub struct FeeCurve {
     pub pool_loss_surcharge_bps: u16,
 }
 
+impl FeeCurve {
+    /// Audit-MED #5: enforce internal ordering and BPS bounds before any
+    /// curve is stored on a `Pool` (init_pool / propose_params). Without
+    /// this, governance could pre-stage a curve where `kink_rate > max_rate`
+    /// or `kink_bps > BPS_DENOMINATOR`. The fee math doesn't panic on
+    /// such inputs but produces nonsense rates (saturating intermediaries
+    /// hide the bug). Cheap to enforce up-front; costs nothing at runtime.
+    ///
+    /// Required invariants:
+    ///   - `utilization_kink_bps <= BPS_DENOMINATOR`
+    ///   - `base_rate_bps <= kink_rate_bps <= max_rate_bps`
+    ///   - `max_rate_bps <= BPS_DENOMINATOR`
+    pub fn validate(&self) -> Result<()> {
+        require!(
+            (self.utilization_kink_bps as u64) <= BPS_DENOMINATOR,
+            crate::errors::CredmeshError::InvalidFeeCurve
+        );
+        require!(
+            self.base_rate_bps <= self.kink_rate_bps,
+            crate::errors::CredmeshError::InvalidFeeCurve
+        );
+        require!(
+            self.kink_rate_bps <= self.max_rate_bps,
+            crate::errors::CredmeshError::InvalidFeeCurve
+        );
+        require!(
+            (self.max_rate_bps as u64) <= BPS_DENOMINATOR,
+            crate::errors::CredmeshError::InvalidFeeCurve
+        );
+        Ok(())
+    }
+}
+
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]
 pub struct PendingParams {
     pub fee_curve: FeeCurve,

--- a/programs/credmesh-receivable-oracle/src/lib.rs
+++ b/programs/credmesh-receivable-oracle/src/lib.rs
@@ -347,11 +347,14 @@ pub struct WorkerUpdateReceivable<'info> {
     pub config: Account<'info, OracleConfig>,
     /// CHECK: Just an address used as a seed.
     pub agent: UncheckedAccount<'info>,
+    /// Audit-MED #3 fix: source_kind byte is part of the seed so a worker-
+    /// owned receivable cannot be clobbered by an `ed25519_record_receivable`
+    /// call (and vice-versa). Worker = `[0]` (`SourceKind::Worker`).
     #[account(
         init_if_needed,
         payer = worker,
         space = Receivable::SIZE,
-        seeds = [RECEIVABLE_SEED, agent.key().as_ref(), source_id.as_ref()],
+        seeds = [RECEIVABLE_SEED, &[0u8], agent.key().as_ref(), source_id.as_ref()],
         bump
     )]
     pub receivable: Account<'info, Receivable>,
@@ -375,11 +378,17 @@ pub struct Ed25519RecordReceivable<'info> {
         constraint = allowed_signer.signer == signer_pubkey @ OracleError::SignerNotAllowed
     )]
     pub allowed_signer: Account<'info, AllowedSigner>,
+    /// Audit-MED #3 fix: source_kind byte (sourced from `allowed_signer.kind`,
+    /// = 1 for exchange, 2 for x402 facilitator) is part of the seed so an
+    /// ed25519-attested receivable cannot collide with a Worker-created one,
+    /// nor can an exchange-kind clobber an x402-kind. The handler later writes
+    /// `receivable.source_kind = signer_acc.kind`, so seed and stored kind
+    /// agree by construction.
     #[account(
         init_if_needed,
         payer = payer,
         space = Receivable::SIZE,
-        seeds = [RECEIVABLE_SEED, agent.key().as_ref(), source_id.as_ref()],
+        seeds = [RECEIVABLE_SEED, &[allowed_signer.kind], agent.key().as_ref(), source_id.as_ref()],
         bump
     )]
     pub receivable: Account<'info, Receivable>,

--- a/tests/bankrun/escrow/request_advance_worker.test.ts
+++ b/tests/bankrun/escrow/request_advance_worker.test.ts
@@ -192,7 +192,7 @@ describe("credmesh-escrow / request_advance — PDA derivation (pure)", () => {
     expect(adv1.equals(adv2)).to.be.false;
   });
 
-  it("Receivable PDA (oracle): seeds = [RECEIVABLE_SEED, agent, source_id]", () => {
+  it("Receivable PDA (oracle): seeds = [RECEIVABLE_SEED, source_kind, agent, source_id] (Audit-MED #3 namespacing)", () => {
     const agent = Keypair.generate().publicKey;
     const sourceId = Buffer.alloc(32, 4);
     const [recv, bump] = receivablePda(agent, sourceId);

--- a/tests/bankrun/receivable_oracle/ed25519_record.test.ts
+++ b/tests/bankrun/receivable_oracle/ed25519_record.test.ts
@@ -152,7 +152,7 @@ describe("credmesh-receivable-oracle / ed25519_record — invariants (pure)", ()
     expect(pda.equals(pdaOther)).to.be.false;
   });
 
-  it("Receivable PDA: seeds = [RECEIVABLE_SEED, agent, source_id]", () => {
+  it("Receivable PDA: seeds = [RECEIVABLE_SEED, source_kind, agent, source_id] (Audit-MED #3 namespacing)", () => {
     const agent = Keypair.generate().publicKey;
     const sourceId = Buffer.alloc(32, 0xc3);
     const [pda] = receivablePda(agent, sourceId);

--- a/tests/bankrun/setup.ts
+++ b/tests/bankrun/setup.ts
@@ -144,9 +144,13 @@ export function oracleConfigPda(): [PublicKey, number] {
 export function receivablePda(
   agent: PublicKey,
   sourceId: Buffer,
+  sourceKind: number = 0, // SourceKind::Worker
 ): [PublicKey, number] {
+  // Audit-MED #3 fix: source_kind byte is part of the seed so a worker-owned
+  // receivable cannot collide with an ed25519-attested one (or vice versa).
+  // Default to Worker (0) since that's the path Bankrun fixtures exercise.
   return PublicKey.findProgramAddressSync(
-    [Buffer.from("receivable"), agent.toBuffer(), sourceId],
+    [Buffer.from("receivable"), Buffer.from([sourceKind]), agent.toBuffer(), sourceId],
     ORACLE_PROGRAM_ID,
   );
 }


### PR DESCRIPTION
Addresses the 3 REAL MED findings from the Kimi K2 external audit (the 2 HIGH findings on `skim_protocol_fees` + cascading `liquidate` were verified as false positives — Kimi misread the dual-ledger separation between `Pool.total_assets` and `Pool.accrued_protocol_fees`).

Each fix is its own commit so the second-stage audit (Claude code-reviewer + Kimi K2 re-run) can isolate them.

**Do NOT merge** until the second-stage audit signs off.

## Commits

| Commit | Audit ID | Severity | What it does |
|---|---|---|---|
| `ba6c861` | MED #3 | REAL | Namespace `Receivable` PDA seeds by `source_kind` |
| `6b1d2fb` | MED #4 | REAL (low v1 impact) | Bound `require_memo_nonce` ix-scan to `MAX_IX_SCAN = 64` |
| `c914b83` | MED #5 | REAL | `FeeCurve::validate()` at `init_pool` + `propose_params` |

## Fix #3 — Receivable PDA namespace clobber

`worker_update_receivable` and `ed25519_record_receivable` previously used `init_if_needed` on identical seeds `[RECEIVABLE_SEED, agent, source_id]` and overwrote every Receivable field including `source_kind`. A compromised `allowed_signer` could clobber a worker-created receivable; vice versa. Escrow's `request_advance` Worker arm did not validate `receivable.source_kind == Worker`, so clobbered data flowed through to the credit decision.

Fixed at the seed layer (Option A from the audit) by adding the `source_kind` byte to the PDA seed:

- `worker_update_receivable`: `[RECEIVABLE_SEED, &[0u8], agent, source_id]` (Worker)
- `ed25519_record_receivable`: `[RECEIVABLE_SEED, &[allowed_signer.kind], agent, source_id]` (1=exchange, 2=x402)
- escrow `RequestAdvance.receivable_pda`: `[RECEIVABLE_SEED, &[0u8], agent, receivable_id]`

The handler at `receivable-oracle/src/lib.rs:203` still writes `receivable.source_kind = signer_acc.kind`, so the seed-encoded kind and the stored field agree by construction. Cross-namespace clobber is now physically impossible at the PDA layer.

Test helper `tests/bankrun/setup.ts::receivablePda()` now takes optional `sourceKind` (default `0` = Worker) so existing Worker-path Bankrun fixtures keep working without changes.

## Fix #4 — `require_memo_nonce` loop cap

In v1 the cranker is constrained to `advance.agent` (AUDIT P0-3), so the unbounded scan is at worst a self-DoS — irrelevant. In v1.5, when `claim_and_settle` becomes permissionless, a malicious cranker could pad the tx with no-op instructions to drive the scan's compute past the per-tx ceiling before the legitimate Memo is reached.

```rust
const MAX_IX_SCAN: usize = 64;
for idx in 0..MAX_IX_SCAN { /* match-and-return-or-continue */ }
```

Solana's tx-size limit (1232 B) caps top-level instructions well below 64 in practice, so the bound costs nothing on the happy path.

## Fix #5 — `FeeCurve::validate()` at init_pool + propose_params

Neither `init_pool` (lib.rs L20+) nor `propose_params` (lib.rs L593+) validated FeeCurve internal ordering or BPS bounds. Governance could legally set `kink_rate_bps > max_rate_bps` or `utilization_kink_bps > BPS_DENOMINATOR`. `compute_fee_amount` doesn't panic on such inputs (saturating intermediates) but produces nonsense rates that the team would only catch by inspecting `AdvanceIssued` events.

New `impl FeeCurve { pub fn validate(&self) -> Result<()> }` in `programs/credmesh-escrow/src/state.rs` enforces:

```
utilization_kink_bps <= BPS_DENOMINATOR
base_rate_bps        <= kink_rate_bps
kink_rate_bps        <= max_rate_bps
max_rate_bps         <= BPS_DENOMINATOR
```

Called from `init_pool` (after existing pct_bps + timelock checks) and `propose_params` (BEFORE staging into `pending_params`, so a malformed curve never enters the timelock window). New error variant `CredmeshError::InvalidFeeCurve` is appended at the end of the enum so existing discriminants don't shift.

## Test plan

- [ ] `anchor build --workspace` (Track A toolchain)
- [ ] Existing Bankrun fixtures still pass — Worker-path receivable lookup helper signature is backward-compat (default `sourceKind = 0`)
- [ ] Add a fixture asserting cross-kind receivable PDAs are distinct (post-merge follow-up; out of scope here per single-PR instruction)
- [ ] Add a fixture asserting `init_pool` + `propose_params` reject `kink_rate > max_rate` curves (post-merge follow-up)
- [ ] Manual: confirm Kimi K2 + Claude code-reviewer second-stage audit signs off before merge

## Out of scope

- The 2 HIGH findings (skim/cascading liquidate) are FALSE POSITIVES per the dual-ledger design (`total_assets` and `accrued_protocol_fees` are intentionally separate; `skim_protocol_fees` correctly only touches the latter; verified at `lib.rs:516-528` post-#30).
- Documentation refresh of DESIGN.md / AUDIT.md to reflect the new Receivable seed shape — leave for the second-stage audit to flag if desired (DESIGN.md doesn't currently document the Receivable PDA seed in its accounts table, so no stale doc claim today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)