### PR TITLE
fix: enable anchor-lang event-cpi feature for emit_cpi! macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 rust-version = "1.75"
 
 [workspace.dependencies]
-anchor-lang = { version = "0.30.1", features = ["init-if-needed"] }
+anchor-lang = { version = "0.30.1", features = ["init-if-needed", "event-cpi"] }
 anchor-spl = "0.30.1"
 # `credmesh-shared` is a library crate, not a deployable Solana program, so it
 # lives in `crates/` rather than `programs/`. Anchor only treats subdirs of

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,113 @@
+# Architecture
+
+CredMesh-Solana is a programmable credit protocol for autonomous agents on Solana. Three deployable programs + one shared library crate.
+
+## High-level
+
+```mermaid
+graph TB
+    subgraph "credmesh deployable programs"
+        ESC[credmesh-escrow<br/>USDC pool, advances, waterfall, liquidate]
+        REP[credmesh-reputation<br/>8004-shape rolling reputation digest]
+        REC[credmesh-receivable-oracle<br/>worker + ed25519 payer-signed receivables]
+    end
+
+    subgraph "library crate"
+        SHA[crates/credmesh-shared<br/>seeds, program_ids, cross-program helpers,<br/>ix introspection, ed25519 message layout]
+    end
+
+    subgraph "external Solana programs (consumed, not deployed)"
+        SPL[SPL Token<br/>USDC vault + share mint]
+        ED[ed25519 native program<br/>signed-receivable verify]
+        MEMO[Memo v2<br/>replay-nonce binding]
+        SQDS[Squads v4<br/>agent vaults + governance<br/>v1 deferred to v1.5]
+        MPL[MPL Agent Registry +<br/>Agent Tools + Core<br/>agent identity, executive profile]
+    end
+
+    ESC -.uses.-> SHA
+    REP -.uses.-> SHA
+    REC -.uses.-> SHA
+
+    ESC -- "typed Account&lt;AgentReputation&gt;<br/>seeds::program" --> REP
+    ESC -- "typed Account&lt;Receivable&gt;<br/>seeds::program (Worker path)" --> REC
+    REP -- "typed Account&lt;OracleConfig&gt;<br/>seeds::program" --> REC
+
+    ESC --> SPL
+    REC --> ED
+    ESC --> MEMO
+
+    ESC -.future.-> SQDS
+    ESC -.future.-> MPL
+```
+
+## Per-program PDAs
+
+```mermaid
+graph LR
+    subgraph "credmesh-escrow PDAs"
+        Pool["Pool<br/>seeds: [POOL, asset_mint]<br/>fields: total_assets, total_shares,<br/>deployed_amount, accrued_protocol_fees,<br/>fee_curve, governance, treasury_ata"]
+        Advance["Advance<br/>seeds: [ADVANCE, pool, agent, receivable_id]<br/>fields: principal, fee_owed,<br/>late_penalty_per_day, expires_at, state<br/>close=agent at settlement"]
+        Consumed["ConsumedPayment<br/>seeds: [CONSUMED, pool, agent, receivable_id]<br/>PERMANENT — never closed (AUDIT P0-5)<br/>replay-protection ledger"]
+    end
+
+    subgraph "credmesh-reputation PDAs"
+        Rep["AgentReputation<br/>seeds: [REPUTATION, agent_asset]<br/>fields: feedback_count,<br/>feedback_digest (32B rolling),<br/>score_ema (u128), default_count,<br/>last_event_slot"]
+    end
+
+    subgraph "credmesh-receivable-oracle PDAs"
+        Cfg["OracleConfig<br/>seeds: [ORACLE_CONFIG]<br/>fields: governance, worker_authority,<br/>caps, reputation_writer_authority"]
+        Recv["Receivable<br/>seeds: [RECEIVABLE, source_kind, agent, source_id]<br/>fields: amount, expires_at, source_kind,<br/>source_signer, last_updated_slot<br/>NAMESPACED by source_kind (PR #32)"]
+        AS["AllowedSigner<br/>seeds: [ALLOWED_SIGNER, signer_pubkey]<br/>fields: kind (1=exchange, 2=x402),<br/>per-receivable + per-period caps"]
+    end
+
+    Pool -- one --> Advance
+    Pool -- one --> Consumed
+    Advance -. matches .- Consumed
+```
+
+## Three-key topology (DESIGN §10)
+
+Three off-chain authorities that MUST never share keys:
+
+```mermaid
+graph LR
+    FP[Fee-payer wallet<br/>pays SOL for tx fees<br/>not a signing authority]
+    OW[Oracle worker authority<br/>signs worker_update_receivable<br/>caps in OracleConfig]
+    RW[Reputation writer authority<br/>signs gated give_feedback writes<br/>controlled by oracle governance]
+
+    FP -.never same as.- OW
+    OW -.never same as.- RW
+    FP -.never same as.- RW
+```
+
+If any two collapse to the same key, a single compromise yields cross-protocol takeover. Rotation flow lives in `DEPLOYMENT.md`.
+
+## Workspace layout
+
+```
+programs/
+  credmesh-escrow/                  Pool vault + share mint + advance issuance + waterfall settlement + liquidate
+  credmesh-reputation/              AgentReputation 8004-shape rolling-digest reputation + writer-gated EMA updates
+  credmesh-receivable-oracle/       Worker-attested + ed25519 payer-signed receivables + allowed-signer registry
+crates/
+  credmesh-shared/                  LIBRARY ONLY (not deployed). Seed constants, program-ID consts, cross-program
+                                    helpers (read_cross_program_account 4-step verify), ix introspection
+                                    (verify_prev_ed25519, require_memo_nonce), ed25519_message layout
+ts/server/                          Hono backend (SIWS auth, tx-builder, webhook ingress)
+tests/bankrun/                      anchor-bankrun: pure-math + scaffolded harness suites by program/attack class
+scripts/                            deploy.ts, init_oracle.ts, init_pool.ts + lib helpers
+target/deploy/                      Committed devnet program keypairs (escrow, reputation, receivable_oracle)
+```
+
+## Cross-program data flow at a glance
+
+| Caller | Reads | Writes | Purpose |
+|---|---|---|---|
+| escrow.request_advance | reputation.AgentReputation, oracle.Receivable (Worker), or instructions sysvar (ed25519/x402) | escrow.Pool, escrow.Advance, escrow.ConsumedPayment | issue an advance |
+| escrow.claim_and_settle | escrow.Advance, escrow.ConsumedPayment | escrow.Pool | settle waterfall |
+| escrow.liquidate | escrow.Advance, escrow.ConsumedPayment | escrow.Pool | post-deadline writeoff |
+| reputation.give_feedback | oracle.OracleConfig (writer-gating + cap) | reputation.AgentReputation | append feedback + update EMA |
+| oracle.worker_update_receivable | oracle.OracleConfig (worker auth + caps) | oracle.Receivable (Worker namespace) | record off-chain attested receivable |
+| oracle.ed25519_record_receivable | oracle.AllowedSigner, instructions sysvar | oracle.Receivable (Exchange/X402 namespace) | record payer-signed receivable |
+
+See `docs/LOGIC_FLOW.md` for the per-handler sequence diagrams.

--- a/docs/LOGIC_FLOW.md
+++ b/docs/LOGIC_FLOW.md
@@ -1,0 +1,237 @@
+# Logic Flow
+
+Sequence diagrams for the canonical handlers. Pair with `docs/ARCHITECTURE.md` for the static structure.
+
+## LP deposit (`escrow::deposit`)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant LP
+    participant ESC as escrow program
+    participant Pool as Pool PDA
+    participant Vault as USDC vault (token acct)
+    participant Mint as Share mint
+    LP->>ESC: deposit(amount)
+    ESC->>Pool: read total_assets, total_shares
+    ESC->>ESC: shares = preview_deposit(amount, total_assets, total_shares)<br/>(virtual-shares offset, OZ ERC-4626 pattern)
+    LP->>Vault: token::transfer(amount) → vault
+    ESC->>Pool: total_assets += amount<br/>total_shares += shares
+    ESC->>Mint: token::mint_to(LP, shares)
+    Note over LP,Mint: First-depositor inflation defense via virtual offsets:<br/>1-atom donation costs ≥ 10⁶ × any extractable profit
+```
+
+## Withdraw (`escrow::withdraw`)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant LP
+    participant ESC as escrow program
+    participant Pool as Pool PDA
+    participant Vault as USDC vault
+    participant Mint as Share mint
+    LP->>ESC: withdraw(shares)
+    ESC->>Pool: read total_assets, total_shares, deployed_amount
+    ESC->>ESC: assets_out = preview_redeem(shares, total_assets, total_shares)
+    ESC->>ESC: require!(assets_out ≤ idle = total_assets - deployed_amount)
+    ESC->>Mint: token::burn(LP, shares)
+    Vault->>LP: token::transfer(assets_out) (PDA-signed)
+    ESC->>Pool: total_assets -= assets_out<br/>total_shares -= shares
+    Note over LP,Vault: Idle-only enforcement: cannot withdraw locked-as-deployed funds
+```
+
+## Request advance — Worker source path (`escrow::request_advance` source_kind=0)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Agent
+    participant ESC as escrow program
+    participant Rep as reputation program
+    participant Recv as receivable-oracle program
+    participant Pool as Pool PDA
+    participant Adv as Advance PDA (init)
+    participant Cons as ConsumedPayment PDA (init)
+    participant Vault as USDC vault
+    participant ATA as agent USDC ATA
+    Agent->>ESC: request_advance(receivable_id, amount, source_kind=0)
+    ESC->>Rep: typed Account<AgentReputation> read<br/>seeds=[REPUTATION, agent_asset], seeds::program=reputation::ID<br/>(Anchor 0.30 4-step verify auto)
+    ESC->>Recv: typed Account<Receivable> read (Some)<br/>seeds=[RECEIVABLE, [0u8], agent, receivable_id]<br/>seeds::program=receivable_oracle::ID<br/>(Worker namespace, post-#32 fix)
+    ESC->>ESC: staleness ≤ MAX_STALENESS_SLOTS
+    ESC->>ESC: amount ≤ min(receivable*pct/10000, abs_cap, credit_from_score_ema)<br/>fee = compute_fee_amount(curve, util, duration, default_count)
+    ESC->>ESC: init Advance PDA<br/>seeds=[ADVANCE, pool, agent, receivable_id]
+    ESC->>ESC: init ConsumedPayment PDA<br/>seeds=[CONSUMED, pool, agent, receivable_id]<br/>(replay protection — PERMANENT)
+    Vault->>ATA: token::transfer(amount) (PDA-signed)
+    ESC->>Pool: deployed_amount += amount<br/>require!(deployed ≤ total_assets)
+    ESC-->>Agent: emit AdvanceIssued
+    Note over Agent,ATA: emit! is the LAST step (project convention)
+```
+
+## Request advance — Ed25519/X402 path (`escrow::request_advance` source_kind=1|2)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Cli as Caller (offchain)
+    participant Agent
+    participant ESC as escrow program
+    participant Rep as reputation program
+    participant Sysvar as Instructions sysvar
+    participant Pool as Pool PDA
+    participant Adv as Advance PDA (init)
+    participant Cons as ConsumedPayment PDA (init)
+    participant Vault as USDC vault
+    Cli->>Cli: build SignedReceivable (96B layout)<br/>sign with allowed_signer key
+    Cli->>ESC: TX = [ed25519_verify_ix, request_advance_ix]
+    ESC->>Sysvar: load_instruction_at_checked(prev_ix)
+    ESC->>ESC: verify_prev_ed25519(): asymmetric.re/Relay-class<br/>fix preserved (binds verify ix to current ix)
+    ESC->>ESC: SignedReceivable::decode() → msg_recv_id, msg_agent,<br/>amount, expires_at, nonce
+    ESC->>ESC: require!(msg_agent == agent_asset.key())<br/>(cross-agent replay defense)
+    ESC->>Rep: typed Account<AgentReputation> read
+    ESC->>ESC: receivable_pda = None (intentional;<br/>ed25519 path doesn't read PDA)
+    ESC->>ESC: cap checks + fee calc (same as Worker)
+    ESC->>ESC: init Advance + ConsumedPayment
+    Vault->>Agent: token::transfer(amount) (PDA-signed)
+    ESC->>Pool: deployed_amount += amount
+    ESC-->>Agent: emit AdvanceIssued
+```
+
+## Settlement waterfall (`escrow::claim_and_settle`)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Cranker as Cranker (== advance.agent in v1, AUDIT P0-3)
+    participant ESC as escrow program
+    participant Adv as Advance PDA
+    participant Cons as ConsumedPayment PDA
+    participant Pool as Pool PDA
+    participant Memo as Memo v2 ix
+    participant PayerAta as payer USDC ATA
+    participant Vault as USDC vault
+    participant ProtoAta as protocol treasury ATA
+    participant AgentAta as agent USDC ATA
+    Cranker->>ESC: TX = [memo_ix(nonce), claim_and_settle(payment_amount)]
+    ESC->>Memo: require_memo_nonce(MAX_IX_SCAN=64)<br/>finds memo with expected nonce<br/>(post-#32 capped scan)
+    ESC->>Adv: read principal, fee_owed, expires_at
+    ESC->>Cons: assert exists with same agent + receivable_id
+    ESC->>ESC: late_days = max(0, now - expires_at) / 86400 (clamped MAX_LATE_DAYS)<br/>late_penalty = late_days × adv.late_penalty_per_day<br/>total_fee = fee_owed + late_penalty
+    ESC->>ESC: protocol_cut = total_fee × 1500 / 10000 (u128)<br/>lp_fee = total_fee - protocol_cut<br/>lp_cut = principal + lp_fee<br/>agent_net = payment_amount - protocol_cut - lp_cut
+    ESC->>ESC: require!(protocol_cut + lp_cut + agent_net == payment_amount)
+    PayerAta->>Vault: transfer(lp_cut)
+    PayerAta->>ProtoAta: transfer(protocol_cut)
+    alt agent_net > 0
+        PayerAta->>AgentAta: transfer(agent_net)
+    end
+    ESC->>Pool: deployed_amount -= principal<br/>total_assets += lp_fee<br/>accrued_protocol_fees += protocol_cut
+    Note over ESC,Pool: total_assets and accrued_protocol_fees<br/>are SEPARATE LEDGERS by design.<br/>skim_protocol_fees touches the latter only.
+    ESC->>Adv: state = Settled, close=agent (rent → agent)
+    ESC->>Cons: NOT closed — permanent (AUDIT P0-5)
+    ESC-->>Cranker: emit AdvanceSettled
+```
+
+## Liquidation (`escrow::liquidate`)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Cranker
+    participant ESC as escrow program
+    participant Adv as Advance PDA
+    participant Cons as ConsumedPayment PDA
+    participant Pool as Pool PDA
+    Cranker->>ESC: liquidate()
+    ESC->>Adv: read expires_at, principal
+    ESC->>ESC: require!(now ≥ expires_at + LIQUIDATION_GRACE_SECONDS)
+    ESC->>Cons: assert consumed.agent == advance.agent (AUDIT P0-1)
+    ESC->>Pool: deployed_amount -= principal<br/>total_assets -= principal (LPs eat the loss)
+    ESC->>Adv: state = Liquidated (NOT closed — AUDIT AM-7 keeps audit trail)
+    ESC->>Cons: NOT closed — permanent
+    ESC-->>Cranker: emit AdvanceLiquidated
+    Note over Cranker,Pool: Cannot liquidate before deadline + grace window.<br/>Share price drops; total_shares unchanged.
+```
+
+## Reputation update (`reputation::give_feedback`)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Cranker
+    participant REP as reputation program
+    participant Cfg as OracleConfig (cross-program read)
+    participant Agent as AgentReputation PDA
+    Cranker->>REP: give_feedback(score, feedback_uri, prev_digest_hash)
+    REP->>Cfg: typed Account<OracleConfig> read<br/>seeds=[ORACLE_CONFIG], seeds::program=oracle::ID
+    alt attestor == oracle_config.reputation_writer_authority
+        REP->>REP: gate passes — score updates allowed
+        REP->>Agent: digest = sha256(prev_digest || feedback_uri || score)<br/>(8004-shape rolling)
+        REP->>Agent: score_ema = EMA(score, alpha=64/1024)
+        REP->>Agent: feedback_count += 1
+        REP->>Agent: if score < default_threshold: default_count += 1
+        REP->>Agent: last_event_slot = current_slot
+    else attestor != writer
+        REP->>Agent: digest update + count bump only<br/>(permissionless audit trail)<br/>NO score change
+    end
+    REP-->>Cranker: emit_cpi! NewFeedback<br/>(via inner-instruction, defends 10KB log truncation)
+    Note over Cranker,Agent: emit_cpi! survives noisy-log adversary tx<br/>(AUDIT defended via PR #11)
+```
+
+## Receivable recording — Worker path (`oracle::worker_update_receivable`)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Worker as Worker authority (off-chain oracle)
+    participant REC as receivable-oracle program
+    participant Cfg as OracleConfig
+    participant Recv as Receivable PDA (init_if_needed)
+    Worker->>REC: worker_update_receivable(source_id, amount, expires_at)
+    REC->>Cfg: constraint: config.worker_authority == worker.key()
+    REC->>REC: lazy period reset if past worker_period_seconds
+    REC->>REC: require!(amount ≤ worker_max_per_tx)<br/>require!(period_used + amount ≤ worker_max_per_period)
+    REC->>Recv: init or update PDA<br/>seeds=[RECEIVABLE, [0u8], agent, source_id]<br/>(post-#32 namespaced by source_kind)
+    REC->>Recv: source_kind=0, source_signer=None,<br/>amount, expires_at, last_updated_slot
+    REC->>Cfg: worker_period_used += amount
+    REC-->>Worker: emit ReceivableUpdated
+```
+
+## Receivable recording — Ed25519 path (`oracle::ed25519_record_receivable`)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Cli as Caller (offchain)
+    participant Payer
+    participant REC as receivable-oracle program
+    participant Sysvar as Instructions sysvar
+    participant AS as AllowedSigner PDA
+    participant Recv as Receivable PDA (init_if_needed)
+    Cli->>Cli: build 96B SignedReceivable<br/>sign with allowed_signer key
+    Payer->>REC: TX = [ed25519_verify_ix, ed25519_record_receivable]
+    REC->>Sysvar: verify_prev_ed25519() returns (verified_pubkey, signed_msg)
+    REC->>REC: 4-layer binding:<br/>(a) ed25519 native verify<br/>(b) verified_pubkey == ix-arg signer_pubkey<br/>(c) AllowedSigner.signer == signer_pubkey<br/>(d) msg fields == ix args (recv_id, agent, amount, expires_at)
+    REC->>AS: read kind, caps
+    REC->>REC: lazy period reset; per-receivable + per-period cap checks
+    REC->>Recv: init or update PDA<br/>seeds=[RECEIVABLE, [allowed_signer.kind], agent, source_id]<br/>(post-#32 namespaced by signer kind 1 or 2)
+    REC->>Recv: source_kind=signer_acc.kind, source_signer=Some(signer_pubkey),<br/>amount, expires_at
+    REC->>AS: period_used += amount
+    REC-->>Payer: emit ReceivableUpdated
+```
+
+---
+
+## Critical invariants enforced across the diagrams
+
+| Invariant | Where | Defends |
+|---|---|---|
+| `deployed_amount ≤ total_assets` | request_advance post-state, withdraw pre-state | Pool can't deploy more than LPs deposited |
+| `cranker == advance.agent` | claim_and_settle, liquidate constraint | AUDIT P0-3/P0-4 — v1 cranker permissioning |
+| `consumed.agent == advance.agent` | claim_and_settle, liquidate | AUDIT P0-1 — cross-agent settle defense |
+| ConsumedPayment PERMANENT | no close handler anywhere | AUDIT P0-5 — close-then-reinit replay defense |
+| Pool has no `paused` field | state.rs | AUDIT P0-6 — issuance never gated |
+| `init` (not `init_if_needed`) for replay PDAs | request_advance Advance + ConsumedPayment | AUDIT P0-5 |
+| `total_assets` and `accrued_protocol_fees` = SEPARATE LEDGERS | claim_and_settle waterfall | LP price not inflated by skimmable fees |
+| Memo nonce scan capped at 64 ix | require_memo_nonce | Post-#32 — DoS defense for v1.5 permissionless cranking |
+| FeeCurve invariants validated at init+propose | init_pool, propose_params | Post-#32 — governance footgun guard |
+| Receivable PDA namespaced by source_kind | seeds in oracle handlers | Post-#32 — cross-path overwrite defense |


### PR DESCRIPTION
Real bug discovered while running first `anchor build --no-idl` for devnet deploy. Compile fails on `credmesh-reputation` because `#[event_cpi]` and `emit_cpi!` (introduced in PR #11) are gated behind anchor-lang's `event-cpi` feature, which the workspace Cargo.toml didn't enable.

The 5-pass audit (Claude × 4 + Kimi K2) all missed this because they reviewed code without compiling. **Compile is the missing test.**

After this fix all 3 program .so files build cleanly:
- credmesh_escrow.so 467 KB
- credmesh_receivable_oracle.so 298 KB
- credmesh_reputation.so 248 KB