### PR TITLE
docs: refresh DESIGN.md (post-#30/#32) + CONTRIBUTING.md (Docker-first)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,57 +1,56 @@
 # Contributing
 
-Welcome. CredMesh Solana is in pre-implementation: research, design, and Anchor scaffolding are done; handler bodies are pending.
+Welcome. CredMesh-Solana v1 is implemented, audited, and partially deployed to devnet. See `README.md` for current status.
 
 ## Read first
 
-1. [`DECISIONS.md`](./DECISIONS.md) — the 5 blocking design questions and their resolutions.
-2. [`AUDIT.md`](./AUDIT.md) — security/account-model/integration findings; what was fixed and what's pending.
-3. [`DESIGN.md`](./DESIGN.md) — implementer spec.
-4. `research/` — supporting docs.
+1. [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md) and [`docs/LOGIC_FLOW.md`](./docs/LOGIC_FLOW.md) — Mermaid diagrams of the static structure + handler sequences.
+2. [`DECISIONS.md`](./DECISIONS.md) — the 5 blocking design questions and their resolutions.
+3. [`AUDIT.md`](./AUDIT.md) — security findings, what was fixed (incl. post-EPIC #9 audit-driven fixes), and what's pending.
+4. [`DESIGN.md`](./DESIGN.md) — implementer spec (kept in sync with current code).
+5. [`DEPLOYMENT.md`](./DEPLOYMENT.md) — Docker build recipe + deploy procedure + key rotation.
+6. [`V1_ACCEPTANCE.md`](./V1_ACCEPTANCE.md) — gating checklist for mainnet.
+7. `research/` — original research artifacts (some superseded; see CONTRARIAN.md for what we redesigned).
 
 ## Setup
 
+The pinned Anchor 0.30.1 + Solana 1.18.26 toolchain has lockfile-drift issues against modern Cargo registry contents. **The canonical build is Docker** — don't try to install the toolchain natively. Full recipe in `DEPLOYMENT.md § Build environment (Docker)`. Quickstart:
+
 ```bash
-# Rust toolchain
-rustup toolchain install 1.79.0
-rustup default 1.79.0
+# Pre-warm cached Docker volumes (one-time):
+docker pull backpackapp/build:v0.30.1
+docker volume create credmesh-rustup
+docker volume create credmesh-cargo-registry
+docker volume create credmesh-cargo-git
+docker volume create credmesh-pt-cache
+docker run --rm -v credmesh-rustup:/root/.rustup backpackapp/build:v0.30.1 \
+  rustup toolchain install 1.86.0 --profile minimal --no-self-update
 
-# Solana CLI
-sh -c "$(curl -sSfL https://release.anza.xyz/v1.18.26/install)"
+# Build the workspace (the wrapper script in DEPLOYMENT.md injects
+# --tools-version v1.50 so cargo-build-sbf doesn't re-install platform-tools).
+# Use `--no-idl` until issue #15 lands; the deployable .so still produces correctly.
 
-# Anchor
-cargo install --git https://github.com/coral-xyz/anchor avm --force
-avm install 0.30.1
-avm use 0.30.1
-
-# Verify
-solana --version          # 1.18.26+
-anchor --version          # 0.30.1
-rustc --version           # 1.79.0+
-
-# Build the workspace
-anchor build
-
-# TypeScript server
-cd ts/server
+# TypeScript tests + server (host-side, no Docker needed)
 npm install
-npm run typecheck
+npm test           # ts-mocha + anchor-bankrun (pure-math suites run today)
+cd ts/server && npm run typecheck
 ```
+
+If you must install the toolchain natively (NOT recommended), see CONTRIBUTING_NATIVE.md (TODO if anyone asks). Otherwise stick to Docker; everything contributors do works that way.
 
 ## What to work on
 
-The first sprint implements handler bodies. Pick one in priority order:
+V1 handlers are implemented + compiled + (mostly) deployed. The active gaps are:
 
-1. **`credmesh-escrow::init_pool`** — sets up Pool PDA, share mint, vault ATA, mints virtual-shares dead supply to Pool PDA itself for first-depositor defense. Self-contained; good first PR.
-2. **`credmesh-escrow::deposit`** + **`credmesh-escrow::withdraw`** — straight u128 mul-div math + token CPI. Pair them.
-3. **`credmesh-receivable-oracle::worker_update_receivable`** + **`add_allowed_signer`** — straightforward ACL'd writes.
-4. **`credmesh-reputation::init_reputation`** + **`give_feedback`** — including the Q4 writer-gated `score_ema` update.
-5. **`credmesh-escrow::request_advance`** (worker path first) — depends on cross-program deserialize helper. Add helper in `credmesh-shared` first.
-6. **`credmesh-escrow::claim_and_settle`** — three-CPI waterfall with checked math; rounding remainder goes to agent.
-7. **`credmesh-escrow::liquidate`** — keeps `Advance` alive with `state = Liquidated`.
-8. **`credmesh-escrow::propose_params`** + **`execute_params`** — Squads CPI verification.
-9. **ed25519 path on `request_advance`** — instruction-introspection helper in `credmesh-shared`. Includes asymmetric.re/Relay-class fix (verify offsets internal to verify ix).
-10. **`request_advance` x402 path** — same as ed25519 but with `source_signer` allowlist gating.
+1. **Issue #15: IDL extraction (E0433 on `AssociatedToken`)** — biggest unlock; activates the harness-mode bankrun tests + TS-client typed-tx + Codama. One-line fix likely in `programs/credmesh-escrow/src/lib.rs:~1006` (add `use anchor_spl::associated_token::AssociatedToken;`); needs a clean rebuild + IDL regen.
+2. **`credmesh-escrow` deploy** — keypair reserved at `DLy82HRrSnSVZfQTxze8CEZwequnGyBcJNvYZX1L9yuF`; needs ~3.5 SOL on the deployer wallet.
+3. **Squads CPI verification on `propose_params`** — currently a `Signer<'info>` constraint; Squads vault PDAs cannot be Signers. Needs an on-chain ix-introspection helper that verifies the ix is `vault_transaction_execute` from the Squads program. Tracked in `DEPLOYMENT.md § Phase 3`.
+4. **Promote bankrun harness scaffolds to live behavioral tests** — currently `expect(true).to.be.true` placeholders pending the IDL fix. Activate once #15 lands.
+5. **`ts/server` route handlers** — SIWS auth middleware works; `POST /agents/:address/advance`, the Helius webhook ingest, and the Codama-generated client are all stubs.
+6. **`ts/dashboard`** — empty. React 19 + Vite + Tailwind + Phantom Connect; SSE-relayed `accountSubscribe` for live timeline.
+7. **Insurance fund / first-loss tranche** (`InsuranceFund` PDA, 5% TVL) — gating LP recruitment.
+
+If you're picking up new work, run an `anchor build --no-idl` first to confirm your local toolchain matches the Docker recipe; otherwise the build will fail on the same drift Track A spent 4 hours debugging.
 
 ## Coding standards
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -144,26 +144,26 @@ Burns `shares` from LP, transfers `assets_returned` USDC out, decrements `total_
 Accounts:
 - `agent` (signer) — agent's authority (Squads vault member or directly)
 - `agent_asset` — Solana Agent Registry asset pubkey (read-only, validated)
-- `agent_reputation_pda` — owned by `credmesh-reputation`, read via re-derive
-- `receivable_pda` — owned by `credmesh-receivable-oracle`, read via re-derive
+- `agent_reputation_pda` — typed `Account<'info, credmesh_reputation::AgentReputation>` with `seeds::program = credmesh_reputation::ID`. Anchor 0.30 runs the four-step verify (owner / address / discriminator / typed deserialize) declaratively (PR #30).
+- `receivable_pda` — typed `Option<Account<'info, credmesh_receivable_oracle::Receivable>>` with `seeds::program = credmesh_receivable_oracle::ID`. Resolves to `Some` iff `source_kind = Worker`; `None` for ed25519/x402 paths (which read the receivable from the signed message via instruction introspection instead).
 - `pool` (mut)
-- `advance_pda` (mut, init)
-- `consumed_pda` (mut, init) — replay protection; `init` semantics fail if exists
+- `advance_pda` (mut, init) — seeds `[ADVANCE, pool, agent, receivable_id]`
+- `consumed_pda` (mut, init) — replay protection; `init` (NOT `init_if_needed`) fails if exists. Seeds `[CONSUMED, pool, agent, receivable_id]` (post-#14: agent in seeds, AUDIT issue #8).
 - `pool_usdc_vault` (mut)
 - `agent_usdc_ata` (mut, init_if_needed)
 - `usdc_mint`
-- `token_program`, `system_program`, `rent`
+- `token_program`, `associated_token_program`, `system_program`, `rent`
 
 Optional:
-- `instructions_sysvar` — required if `source_kind = 1` (ed25519 verify pre-instruction)
+- `instructions_sysvar` — required if `source_kind ∈ {Ed25519, X402}` (verify-prev ed25519 introspection)
 
 Logic:
-1. **Replay**: `consumed_pda` init succeeds iff this `receivable_id` has never been used.
+1. **Replay**: `consumed_pda` init succeeds iff this `(pool, agent, receivable_id)` tuple has never been used.
 2. **Receivable verification** by `source_kind`:
-   - `0` (worker): re-derive `receivable_pda`, deserialize, check `last_updated_slot` recency.
-   - `1` (ed25519): instruction-introspection on previous instruction; verify it called the ed25519 program with `(source_signer pubkey, expected message: receivable_id || agent || amount || expiry, signature)`.
-   - `2` (x402): same as `1` but `source_signer` must be in the Pool's allowlist (CredMesh-curated facilitators).
-3. **Credit check**: re-derive `agent_reputation_pda`. Read `score_ema` (u64 with `score_decimals`). Apply `Pool.fee_curve` tier curve to compute `max_credit`.
+   - `Worker (0)`: typed `receivable_pda` resolves to `Some`. The seed shape is `[RECEIVABLE_SEED, &[0u8], agent, source_id]` (post-#32 source_kind namespace). Staleness check: `slot - receivable.last_updated_slot ≤ MAX_STALENESS_SLOTS`.
+   - `Ed25519 (1)`: ix-introspection on previous instruction; verify it called the ed25519 program with the canonical 96-byte `SignedReceivable` message (`receivable_id || agent || amount || expires_at || nonce`). Asymmetric.re/Relay-class index check enforced via `verify_prev_ed25519` in `crates/credmesh-shared::ix_introspection`.
+   - `X402 (2)`: same as Ed25519 but `source_signer` must match an `AllowedSigner` PDA on the oracle program with `kind = 2`.
+3. **Credit check**: typed read of `agent_reputation_pda.score_ema` (u128) and `default_count` (no manual deserialize). Apply `Pool.fee_curve` tier curve via `credit_from_score_ema()` to compute `max_credit`.
 4. **Cap check**: `amount <= min(receivable_amount * max_advance_pct_bps / 10000, max_advance_abs, max_credit)`.
 5. **Fee compute**: `fee_owed = price(amount, utilization_after, duration, risk)` — `pricing.ts` math, ported.
 6. **Settle math**: `Pool.deployed_amount += principal`. Init `Advance` PDA. Transfer `principal` USDC from `pool_usdc_vault` to `agent_usdc_ata`.
@@ -340,7 +340,11 @@ pub struct AllowedSigner {             // for x402 facilitators / known exchange
 - `ed25519_record_receivable(agent, source_id, amount, expires_at)` — caller passes, ed25519 verify in prior instruction; oracle just persists
 - `add_allowed_signer(signer, kind, caps)` / `remove_allowed_signer` — governance only
 
-The escrow's `request_advance` may bypass this program for `source_kind=1` and verify the ed25519 directly without reading a Receivable PDA — that's the cleanest path for x402. The PDA storage is for `source_kind=0` (worker) so the receivable is durable for staleness checks.
+The escrow's `request_advance` bypasses the Receivable PDA for `source_kind ∈ {Ed25519, X402}` and verifies the ed25519 message directly via instruction introspection — that's the cleanest path for x402 facilitators and exchange-signed receivables. The PDA storage is for `source_kind = Worker` so the receivable is durable for staleness checks.
+
+**PDA namespace (post-#32):** Receivable PDAs are seeded as `[RECEIVABLE_SEED, &[source_kind_byte], agent, source_id]`. The Worker writer hardcodes `&[0u8]`; ed25519 writers use `&[allowed_signer.kind]` (1 = exchange, 2 = x402). This eliminates cross-path overwrite (a compromised allowed_signer cannot clobber a worker-attested receivable, and vice versa).
+
+**Reinitialization semantics:** both writer paths use `init_if_needed` so legitimate refreshes (worker re-attests a higher amount, or an exchange re-attests after correction) are allowed. Authority is bounded by per-signer caps (`worker_max_per_period`, `AllowedSigner.max_per_period`).
 
 ## 6. Off-chain server changes
 


### PR DESCRIPTION
Two stale docs caught up to current code state.

**DESIGN.md** — request_advance accounts now reflect the post-#30 typed Account<AgentReputation> + Option<Account<Receivable>> with seeds::program (was "owned by X, read via re-derive"). ConsumedPayment seeds include agent.key() (post-#14). Receivable PDAs namespaced by source_kind (post-#32). 4-layer ed25519 binding documented.

**CONTRIBUTING.md** — replace native rustup/solana-install setup with Docker-first recipe (the pinned 0.30.1 / 1.18.26 / platform-tools combo hits lockfile drift on fresh installs). Active-gap TODO list replaces the now-completed pre-implementation handler list.

Pure docs. No source/test changes.