### PR TITLE
chore: gitignore KEYS.md (local-only key reference)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ test-ledger/
 # committed to docs/sessions/ as point-in-time snapshots if they're worth
 # keeping)
 ORCHESTRATOR_LOG.md
+
+# Local-only key reference (NEVER commit; document of where keys live on this dev machine)
+KEYS.md


### PR DESCRIPTION
Pre-emptive .gitignore line so a local KEYS.md (developer-machine inventory of where private keys live) cannot be accidentally tracked. The file itself is local-only and never committed.