### PR TITLE
chore: gitignore branding/ (WIP, not for merge)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ ORCHESTRATOR_LOG.md
 
 # Local-only key reference (NEVER commit; document of where keys live on this dev machine)
 KEYS.md
+
+# Branding work — local WIP, not merge-ready. Excluded until it's finalized.
+branding/


### PR DESCRIPTION
Brand spec is mid-iteration; not ready to land on main. Excluding the directory until it's finalized.