### PR TITLE
fix: anchor IDL extraction (issue #15)

### DIFF
--- a/programs/credmesh-escrow/src/lib.rs
+++ b/programs/credmesh-escrow/src/lib.rs
@@ -1,5 +1,11 @@
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::sysvar::instructions as sysvar_instructions;
+// Issue #15: bring `AssociatedToken` into module scope so the IDL-extraction
+// build (`cargo test --features idl-build`) resolves the type. Anchor 0.30's
+// `Program<'info, T>` generic does not see `anchor_spl::associated_token` via
+// the fully-qualified path under that profile even with `anchor-spl/associated_token`
+// active on the `idl-build` feature group.
+use anchor_spl::associated_token::AssociatedToken;
 use anchor_spl::token::{self, Burn, Mint, MintTo, Token, TokenAccount, Transfer};
 
 pub mod errors;
@@ -1008,7 +1014,7 @@ pub struct RequestAdvance<'info> {
     #[account(address = sysvar_instructions::ID)]
     pub instructions_sysvar: UncheckedAccount<'info>,
     pub token_program: Program<'info, Token>,
-    pub associated_token_program: Program<'info, anchor_spl::associated_token::AssociatedToken>,
+    pub associated_token_program: Program<'info, AssociatedToken>,
     pub system_program: Program<'info, System>,
 }
 


### PR DESCRIPTION
## Summary
- Closes the long-standing IDL-extraction failure (`error[E0433]: failed to resolve: use of undeclared type AssociatedToken` at `programs/credmesh-escrow/src/lib.rs:1006`) that has forced every build to use `--no-idl`.
- Pulls `anchor_spl::associated_token::AssociatedToken` into module scope and uses the bare identifier in the `RequestAdvance` `#[derive(Accounts)]` struct. Anchor 0.30's IDL build (`cargo test --features idl-build`) cannot resolve the fully-qualified path even with the `anchor-spl/associated_token` feature active on the `idl-build` feature group; the unqualified reference works.
- One-file change in escrow only. No `Cargo.toml`, workspace, or sibling-program edits.

## Result
After this change, `anchor build` (no `--no-idl`) emits all three IDLs:
| File | Instructions | Accounts | Types |
| ---- | ---: | ---: | ---: |
| `target/idl/credmesh_escrow.json` | 9 | 5 | 18 |
| `target/idl/credmesh_reputation.json` | 4 | 2 | 7 |
| `target/idl/credmesh_receivable_oracle.json` | 8 | 3 | 8 |

`request_advance.associated_token_program` resolves to `ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL` in the IDL — confirming the type binding survived round-trip.

## Test plan
- [x] Reproduced the original `E0433` with `anchor build` against the canonical Docker recipe in `DEPLOYMENT.md` § "Build environment (Docker)" before the fix.
- [x] `anchor build` (no `--no-idl`) succeeds end-to-end after the fix; all three `target/idl/*.json` files are produced.
- [x] Each IDL parses as valid JSON inside the build container; `metadata.name` and instruction/account/type counts look sensible.
- [x] `.so` artifacts still produced for all three programs.
- [ ] Follow-up: activate the harness-mode bankrun tests that were stubbed with `expect(true).to.be.true` placeholders pending IDL availability.
- [ ] Follow-up: wire `npx codama run` once a codama config is added (none in repo today).
- [ ] Follow-up: README/CONTRIBUTING/DEPLOYMENT no longer need the `--no-idl` workaround note; documentation cleanup left for a separate PR.

## Risk notes
- Pure rename: the fully-qualified path and the unqualified-import-then-bare-name compile to the same type binding, so the deployed `.so` is unaffected.
- No change to account ordering, signer/writability flags, seeds, or PDA derivations.
- The added doc comment explains *why* the import is needed so a future reader doesn't "clean it up" back to the qualified path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)