### PR TITLE
fix(escrow): claim_and_settle — replace pre-window guard with upper-bound only (M1/M2)

### DIFF
--- a/programs/credmesh-escrow/src/instructions/claim_and_settle.rs
+++ b/programs/credmesh-escrow/src/instructions/claim_and_settle.rs
@@ -6,7 +6,7 @@ use crate::errors::CredmeshError;
 use crate::events::AdvanceSettled;
 use crate::state::{
     Advance, AdvanceState, ConsumedPayment, Pool, ADVANCE_SEED, BPS_DENOMINATOR,
-    CLAIM_WINDOW_SECONDS, CONSUMED_SEED, MAX_LATE_DAYS, POOL_SEED, PROTOCOL_FEE_BPS,
+    CONSUMED_SEED, LIQUIDATION_GRACE_SECONDS, MAX_LATE_DAYS, POOL_SEED, PROTOCOL_FEE_BPS,
 };
 
 /// Single-mode settlement: the agent calls this themselves with USDC in
@@ -79,14 +79,20 @@ pub struct ClaimAndSettle<'info> {
 pub fn handler(ctx: Context<ClaimAndSettle>, payment_amount: u64) -> Result<()> {
     let now = Clock::get()?.unix_timestamp;
 
-    // Settlement window opens at `expires_at - CLAIM_WINDOW_SECONDS`.
-    let claim_window_start = ctx
+    // Settlement is allowed any time from issuance up to the moment
+    // liquidation becomes eligible (`expires_at + LIQUIDATION_GRACE_SECONDS`).
+    // No lower bound — the use case is many micro-loans with very fast
+    // repayment (agents pulling advances for inference costs, settling
+    // within minutes), so any pre-expiry gate would block the common path.
+    // The strict `<` keeps `claim_and_settle` and `liquidate` mutually
+    // exclusive at the exact transition timestamp.
+    let claim_window_end = ctx
         .accounts
         .advance
         .expires_at
-        .checked_sub(CLAIM_WINDOW_SECONDS)
+        .checked_add(LIQUIDATION_GRACE_SECONDS)
         .ok_or(CredmeshError::MathOverflow)?;
-    require!(now >= claim_window_start, CredmeshError::NotSettleable);
+    require!(now < claim_window_end, CredmeshError::NotSettleable);
 
     // Memo-nonce binding: the tx must include a Memo ix carrying the
     // ConsumedPayment.nonce bytes. Defends against the

--- a/programs/credmesh-escrow/src/state.rs
+++ b/programs/credmesh-escrow/src/state.rs
@@ -7,7 +7,11 @@ pub use credmesh_shared::seeds::{
 pub const PROTOCOL_FEE_BPS: u16 = 1500;
 pub const BPS_DENOMINATOR: u64 = 10_000;
 
-pub const CLAIM_WINDOW_SECONDS: i64 = 7 * 24 * 60 * 60;
+// CLAIM_WINDOW_SECONDS removed — settlement now allowed any time from
+// issuance up to `expires_at + LIQUIDATION_GRACE_SECONDS`, gated only on
+// the upper bound. The pre-pivot 7-day lower-bound guard blocked the
+// dominant micro-loan use case (advances with TTLs measured in minutes,
+// not days).
 pub const LIQUIDATION_GRACE_SECONDS: i64 = 14 * 24 * 60 * 60;
 
 pub const VIRTUAL_ASSETS_OFFSET: u64 = 1_000_000;

--- a/ts/shared/package-lock.json
+++ b/ts/shared/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "@credmesh/solana-shared",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@credmesh/solana-shared",
+      "version": "0.0.1",
+      "devDependencies": {
+        "typescript": "^5.6.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/ts/shared/src/index.ts
+++ b/ts/shared/src/index.ts
@@ -21,7 +21,9 @@ export const ATTESTOR_CONFIG_SEED = "attestor_config";
 
 // ── Time constants (mirror programs/credmesh-escrow/src/state.rs) ──────────
 
-export const CLAIM_WINDOW_SECONDS = 7 * 24 * 60 * 60;
+// CLAIM_WINDOW_SECONDS removed — settlement now allowed any time from
+// issuance up to `expires_at + LIQUIDATION_GRACE_SECONDS`. The on-chain
+// handler gates only the upper bound.
 export const LIQUIDATION_GRACE_SECONDS = 14 * 24 * 60 * 60;
 export const MAX_LATE_DAYS = 365;
 


### PR DESCRIPTION
## Summary

Closes M1/M2 from `HANDOFF_REVIEW.md`. Raul's pick was **option (c)**: settle anytime up to `expires_at + grace`, hard upper bound only.

**Before:** \`require!(now >= advance.expires_at - CLAIM_WINDOW_SECONDS (7d))\` — gated a *lower* bound. For 15-min-TTL micro-loans this always failed (\`expires_at - 7d\` is in the past).

**After:** \`require!(now < advance.expires_at + LIQUIDATION_GRACE_SECONDS (14d))\` — gates only the *upper* bound. Settlement allowed from issuance until liquidation becomes eligible.

The strict \`<\` keeps \`claim_and_settle\` and \`liquidate\` mutually exclusive at the transition instant.

\`CLAIM_WINDOW_SECONDS\` removed from \`state.rs\` and the \`ts/shared\` mirror — no other callers.

## Verification

- \`cargo test --workspace --lib --locked\` — 16 pricing + 3 program-id tests, green.
- \`tsc --noEmit\` on \`ts/shared\` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)