### PR TITLE
fix(escrow): liquidate rent → cranker + LiquidationTombstone for audit trail (D2)

### DIFF
--- a/crates/credmesh-shared/src/lib.rs
+++ b/crates/credmesh-shared/src/lib.rs
@@ -16,6 +16,11 @@ pub mod seeds {
     pub const ALLOWED_SIGNER_SEED: &[u8] = b"allowed_signer";
     pub const ATTESTOR_CONFIG_SEED: &[u8] = b"attestor_config";
     pub const ISSUANCE_LEDGER_SEED: &[u8] = b"issuance_ledger";
+    /// Audit-trail PDA initialized at `liquidate`. The `Advance` PDA is
+    /// closed to the cranker (rent → cranker as the third-party
+    /// incentive); the tombstone preserves the bare facts of the
+    /// default for off-chain reconstruction.
+    pub const LIQUIDATION_TOMBSTONE_SEED: &[u8] = b"liq_tombstone";
 }
 
 pub mod program_ids {

--- a/programs/credmesh-escrow/src/instructions/liquidate.rs
+++ b/programs/credmesh-escrow/src/instructions/liquidate.rs
@@ -3,24 +3,29 @@ use anchor_lang::prelude::*;
 use crate::errors::CredmeshError;
 use crate::events::AdvanceLiquidated;
 use crate::state::{
-    Advance, AdvanceState, ConsumedPayment, Pool, ADVANCE_SEED, CONSUMED_SEED,
-    LIQUIDATION_GRACE_SECONDS, POOL_SEED,
+    Advance, AdvanceState, ConsumedPayment, LiquidationTombstone, Pool, ADVANCE_SEED,
+    CONSUMED_SEED, LIQUIDATION_GRACE_SECONDS, LIQUIDATION_TOMBSTONE_SEED, POOL_SEED,
 };
 
 #[derive(Accounts)]
 pub struct Liquidate<'info> {
     #[account(mut)]
     pub cranker: Signer<'info>,
-    /// AUDIT AM-7: keep `Advance` alive after liquidation for audit trail.
-    /// Only `state` mutates to `Liquidated`. Closure happens via a separate
-    /// admin-grace-period cleanup ix in a future version.
+
+    /// `Advance` is **closed** to the cranker on liquidation. Rent refund is
+    /// the third-party liquidation incentive; without it, no permissionless
+    /// keeper market forms. The audit-trail concern that previously gated
+    /// closure (AUDIT AM-7) is preserved by the `LiquidationTombstone` PDA
+    /// initialized in this same handler.
     #[account(
         mut,
         seeds = [ADVANCE_SEED, pool.key().as_ref(), advance.agent.as_ref(), advance.receivable_id.as_ref()],
         bump = advance.bump,
-        constraint = advance.state == AdvanceState::Issued @ CredmeshError::InvalidAdvanceState
+        constraint = advance.state == AdvanceState::Issued @ CredmeshError::InvalidAdvanceState,
+        close = cranker
     )]
     pub advance: Account<'info, Advance>,
+
     /// AUDIT P0-1: bind consumed.agent == advance.agent (was missing).
     /// AUDIT P0-5: ConsumedPayment is NOT closed.
     /// Issue #8: seeds include advance.agent so the PDA derivation enforces
@@ -31,8 +36,25 @@ pub struct Liquidate<'info> {
         constraint = consumed.agent == advance.agent @ CredmeshError::ReplayDetected
     )]
     pub consumed: Account<'info, ConsumedPayment>,
+
+    /// Permanent audit-trail PDA. `init` (not `init_if_needed`) — a second
+    /// `liquidate` against the same `(pool, agent, receivable_id)` is
+    /// already blocked by `Advance.state` being terminal after the first
+    /// run, but the `init` failure on a duplicate tombstone is the
+    /// belt-and-suspenders defense.
+    #[account(
+        init,
+        payer = cranker,
+        space = 8 + LiquidationTombstone::INIT_SPACE,
+        seeds = [LIQUIDATION_TOMBSTONE_SEED, pool.key().as_ref(), advance.agent.as_ref(), advance.receivable_id.as_ref()],
+        bump
+    )]
+    pub tombstone: Account<'info, LiquidationTombstone>,
+
     #[account(mut, seeds = [POOL_SEED, pool.asset_mint.as_ref()], bump = pool.bump)]
     pub pool: Account<'info, Pool>,
+
+    pub system_program: Program<'info, System>,
 }
 
 pub fn handler(ctx: Context<Liquidate>) -> Result<()> {
@@ -47,6 +69,7 @@ pub fn handler(ctx: Context<Liquidate>) -> Result<()> {
 
     let principal = ctx.accounts.advance.principal;
     let agent = ctx.accounts.advance.agent;
+    let expires_at = ctx.accounts.advance.expires_at;
     let advance_key = ctx.accounts.advance.key();
 
     // LPs eat the loss via share-price drop. Total assets decrease by the
@@ -61,9 +84,15 @@ pub fn handler(ctx: Context<Liquidate>) -> Result<()> {
         .checked_sub(principal)
         .ok_or(CredmeshError::MathOverflow)?;
 
-    // AUDIT AM-7: keep `Advance` alive with state=Liquidated for audit trail.
-    let advance = &mut ctx.accounts.advance;
-    advance.state = AdvanceState::Liquidated;
+    // Write the tombstone before `Advance` is closed by Anchor's
+    // `close = cranker` post-handler hook. The fields here are the
+    // minimum fact-set for off-chain reconstruction.
+    let tombstone = &mut ctx.accounts.tombstone;
+    tombstone.bump = ctx.bumps.tombstone;
+    tombstone.agent = agent;
+    tombstone.principal = principal;
+    tombstone.expires_at = expires_at;
+    tombstone.liquidated_at = now;
 
     emit!(AdvanceLiquidated {
         pool: pool.key(),

--- a/programs/credmesh-escrow/src/state.rs
+++ b/programs/credmesh-escrow/src/state.rs
@@ -1,7 +1,7 @@
 use anchor_lang::prelude::*;
 
 pub use credmesh_shared::seeds::{
-    ADVANCE_SEED, CONSUMED_SEED, ISSUANCE_LEDGER_SEED, POOL_SEED,
+    ADVANCE_SEED, CONSUMED_SEED, ISSUANCE_LEDGER_SEED, LIQUIDATION_TOMBSTONE_SEED, POOL_SEED,
 };
 
 pub const PROTOCOL_FEE_BPS: u16 = 1500;
@@ -165,6 +165,26 @@ pub struct ConsumedPayment {
     pub nonce: [u8; 16],
     pub agent: Pubkey,
     pub created_at: i64,
+}
+
+/// Audit-trail PDA written at `liquidate`. The `Advance` PDA is closed
+/// to the cranker (rent refund = third-party liquidation incentive);
+/// the tombstone preserves the minimum fact-set needed to reconstruct
+/// the default off-chain — agent, principal lost, expiry, liquidation
+/// timestamp. **Permanent** like `ConsumedPayment`: never closed.
+///
+/// Seeds: `[LIQUIDATION_TOMBSTONE_SEED, pool, agent, receivable_id]`
+/// — mirrors the `Advance` PDA's seeds so the off-chain bridge tail can
+/// derive the tombstone deterministically from the same `AdvanceIssued`
+/// event it already indexed.
+#[account]
+#[derive(InitSpace)]
+pub struct LiquidationTombstone {
+    pub bump: u8,
+    pub agent: Pubkey,
+    pub principal: u64,
+    pub expires_at: i64,
+    pub liquidated_at: i64,
 }
 
 // ProtocolTreasury is not a separate PDA in v1 — `Pool.treasury_ata` stores the

--- a/ts/keeper/package-lock.json
+++ b/ts/keeper/package-lock.json
@@ -1288,7 +1288,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/ts/keeper/src/index.ts
+++ b/ts/keeper/src/index.ts
@@ -122,7 +122,9 @@ interface LiquidateAccounts {
   cranker: Address;
   advance: Address;
   consumed: Address;
+  tombstone: Address;
   pool: Address;
+  systemProgram: Address;
 }
 
 async function buildLiquidateIx(
@@ -131,13 +133,17 @@ async function buildLiquidateIx(
   liquidateDiscriminator: Uint8Array,
 ) {
   // Anchor liquidate ix has no args beyond the discriminator.
+  // Account order MUST match the Liquidate<'info> struct in
+  // programs/credmesh-escrow/src/instructions/liquidate.rs.
   return {
     programAddress: programId,
     accounts: [
       { address: accounts.cranker, role: AccountRole.WRITABLE_SIGNER },
       { address: accounts.advance, role: AccountRole.WRITABLE },
       { address: accounts.consumed, role: AccountRole.READONLY },
+      { address: accounts.tombstone, role: AccountRole.WRITABLE },
       { address: accounts.pool, role: AccountRole.WRITABLE },
+      { address: accounts.systemProgram, role: AccountRole.READONLY },
     ],
     data: liquidateDiscriminator,
   };
@@ -171,6 +177,24 @@ async function deriveConsumedPda(
     programAddress: ESCROW_PROGRAM_ID,
     seeds: [
       CONSUMED_SEED,
+      getAddressEncoder().encode(pool),
+      agent,
+      receivableId,
+    ],
+  });
+  return pda;
+}
+
+async function deriveTombstonePda(
+  pool: Address,
+  agent: Uint8Array,
+  receivableId: Uint8Array,
+): Promise<Address> {
+  const LIQUIDATION_TOMBSTONE_SEED = new TextEncoder().encode("liq_tombstone");
+  const [pda] = await getProgramDerivedAddress({
+    programAddress: ESCROW_PROGRAM_ID,
+    seeds: [
+      LIQUIDATION_TOMBSTONE_SEED,
       getAddressEncoder().encode(pool),
       agent,
       receivableId,
@@ -259,10 +283,20 @@ async function tick(deps: {
   // we cap at the batch size since liquidation events are rare per-tick.
   const results = await Promise.allSettled(
     liquidatable.map(async (adv) => {
-      const consumedPda = await deriveConsumedPda(pool, adv.agent, adv.receivableId);
+      const [consumedPda, tombstonePda] = await Promise.all([
+        deriveConsumedPda(pool, adv.agent, adv.receivableId),
+        deriveTombstonePda(pool, adv.agent, adv.receivableId),
+      ]);
       const ix = await buildLiquidateIx(
         ESCROW_PROGRAM_ID,
-        { cranker: signer.address, advance: adv.pubkey, consumed: consumedPda, pool },
+        {
+          cranker: signer.address,
+          advance: adv.pubkey,
+          consumed: consumedPda,
+          tombstone: tombstonePda,
+          pool,
+          systemProgram: address("11111111111111111111111111111111"),
+        },
         liquidateDiscriminator,
       );
       const tx = pipe(

--- a/ts/shared/src/index.ts
+++ b/ts/shared/src/index.ts
@@ -18,6 +18,7 @@ export const ADVANCE_SEED = "advance";
 export const CONSUMED_SEED = "consumed";
 export const ALLOWED_SIGNER_SEED = "allowed_signer";
 export const ATTESTOR_CONFIG_SEED = "attestor_config";
+export const LIQUIDATION_TOMBSTONE_SEED = "liq_tombstone";
 
 // ── Time constants (mirror programs/credmesh-escrow/src/state.rs) ──────────
 


### PR DESCRIPTION
## Summary

Closes D2 from \`HANDOFF_REVIEW.md\`. Your pick: **option (b)** — tombstone PDA + close \`Advance\` to cranker.

**Before:** \`liquidate\` kept \`Advance\` alive (\`state = Liquidated\`) to satisfy AUDIT AM-7. Cranker paid tx fee with **no rent refund** → no permissionless keeper market.

**After:**
- \`Advance\` is now \`close = cranker\`. Rent refund (~0.002 SOL per liquidation) is the third-party liquidation incentive.
- New \`LiquidationTombstone\` PDA (permanent, seeds \`[LIQUIDATION_TOMBSTONE_SEED, pool, agent, receivable_id]\` — mirrors \`Advance\` so off-chain consumers can derive deterministically from the \`AdvanceIssued\` event they already indexed).
- Tombstone holds the minimum fact-set: \`agent\`, \`principal\`, \`expires_at\`, \`liquidated_at\`.

\`ConsumedPayment\` unchanged (still permanent per AUDIT P0-5).

## Off-chain knock-on

- \`LIQUIDATION_TOMBSTONE_SEED\` added to \`crates/credmesh-shared/src/seeds\` + \`ts/shared\` mirror.
- \`ts/keeper/src/index.ts\` ix accounts updated: \`tombstone\` + \`system_program\` appended after \`pool\`. \`deriveTombstonePda\` mirrors \`deriveConsumedPda\`.

## Verification

- \`cargo test --workspace --lib --locked\` — 16 pricing + 3 program-id, green.
- \`cargo check --workspace --locked\` — green (one pre-existing \`ambiguous_glob_reexports\` warning unrelated to this PR).
- \`tsc --noEmit\` on \`ts/shared\` + \`ts/keeper\` — green.

## Not yet verified

- bankrun end-to-end (PR #60 covers that surface; this PR doesn't touch the harness).
- Mainnet keeper economics — \`Advance\` rent refund minus \`LiquidationTombstone\` allocation cost = net positive at current rent rates, but worth a sanity check before promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)